### PR TITLE
fixed minor typo for rendering readme markdown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,6 @@ a repository object?
 | Required | Argument | Type | Default | Description |
 |----------|----------|---------|---------|-------------------------------------------------------------------------------------------|
 | [x]   | user | string | - | the user or user set who wants to take the action. Examples: “1”, “organization:1#owners”
-|
 | [x]   | action | string | - | the action the user wants to perform on the resource |
 | [x]   | object | string | - | name and id of the resource. Example: “organization:1” |
 | [ ]   | depth | integer | 8 | |


### PR DESCRIPTION
fixed minor typo for rendering readme github markdown.

before,
![CleanShot 2022-07-15 at 02 15 32](https://user-images.githubusercontent.com/86035/179080946-8c5afb27-0e6e-4d10-bde8-f8860ead95c9.png)

after,
![CleanShot 2022-07-15 at 02 16 02](https://user-images.githubusercontent.com/86035/179080990-f934c018-6c9c-4044-84ee-6f334f30c5b3.png)

