### PR TITLE
Add permify playground link to navbar

### DIFF
--- a/docs/documentation/docusaurus.config.js
+++ b/docs/documentation/docusaurus.config.js
@@ -70,6 +70,12 @@ const config = {
               ],
             },
             {
+              label: 'Permify Playground',
+              href: 'https://play.permify.co',
+              position: 'left',
+              className: 'header-playground-link'
+            },
+            {
               href: 'https://github.com/Permify/permify',
               position: 'right',
               className: 'header-github-link'


### PR DESCRIPTION
Adds the permify playground link to the docs navbar. 
Closes #88 