### PR TITLE
Change the name of playground tab

### DIFF
--- a/docs/documentation/docusaurus.config.js
+++ b/docs/documentation/docusaurus.config.js
@@ -70,7 +70,7 @@ const config = {
               ],
             },
             {
-              label: 'Permify Playground',
+              label: 'Playground',
               href: 'https://play.permify.co',
               position: 'left',
               className: 'header-playground-link'


### PR DESCRIPTION
Change the name of playground tab in top navbar