### PR TITLE
Implement Client-Side Authentication using Pre-shared Key

### DIFF
--- a/internal/authn/preshared/authn.go
+++ b/internal/authn/preshared/authn.go
@@ -48,3 +48,17 @@ func (a *KeyAuthn) Authenticate(ctx context.Context) error {
 	}
 	return status.Error(codes.Unauthenticated, base.ErrorCode_ERROR_CODE_INVALID_KEY.String())
 }
+
+// Get Request Metadata - gets the current request metadata, refreshing tokens
+// if required
+func (a *KeyAuthn) GetRequestMetadata(_ context.Context, uri ...string) (map[string]string, error) {
+    return map[string]string{
+        "Authorization": "Bearer " + "test",
+    }, nil
+}
+
+// RequireTransportSecurity indicates whether the credentials requires
+// transport security.
+func (a *KeyAuthn) RequireTransportSecurity() bool {
+    return true
+}

--- a/internal/engines/balancer/balancer.go
+++ b/internal/engines/balancer/balancer.go
@@ -61,11 +61,16 @@ func NewCheckEngineWithBalancer(
 	// 1. Initialize the KeyAuthn structure using the provided configuration.
 	// 2. Convert the KeyAuthn instance into PerRPCCredentials.
 	// 3. Append grpc.WithPerRPCCredentials() to the options slice.
+	createPresharedKeyAuthN, err := preshared.NewKeyAuthn(context.Background(), authn.Preshared)
+    if err != nil {
+        return nil, fmt.Errorf("could not create authentication key: %s", err)
+    }
 
 	options = append(
 		options,
 		grpc.WithDefaultServiceConfig(grpcServicePolicy),
 		grpc.WithTransportCredentials(creds),
+		grpc.WithPerRPCCredentials(createPresharedKeyAuthN)
 	)
 
 	conn, err := grpc.Dial(dst.Address, options...)

--- a/internal/engines/balancer/balancer.go
+++ b/internal/engines/balancer/balancer.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/Permify/permify/internal/authn/preshared"
 	"github.com/Permify/permify/internal/config"
 	"github.com/Permify/permify/internal/engines"
 	"github.com/Permify/permify/internal/invoke"

--- a/internal/engines/balancer/balancer.go
+++ b/internal/engines/balancer/balancer.go
@@ -70,7 +70,7 @@ func NewCheckEngineWithBalancer(
 		options,
 		grpc.WithDefaultServiceConfig(grpcServicePolicy),
 		grpc.WithTransportCredentials(creds),
-		grpc.WithPerRPCCredentials(createPresharedKeyAuthN)
+		grpc.WithPerRPCCredentials(createPresharedKeyAuthN),
 	)
 
 	conn, err := grpc.Dial(dst.Address, options...)


### PR DESCRIPTION
### Summary
As per [this](https://github.com/Permify/permify/issues/770) issue, this PR implements client-side authentication using pre-shared key.

I have not implemented OIDC authentication as yet since I need clarity on whether I'm moving in the right direction here.

### Links
Below are some links I read to understand pre-shared keys, OIDC and GRPC.
- https://en.wikipedia.org/wiki/Pre-shared_key
- https://pkg.go.dev/google.golang.org/grpc/credentials#PerRPCCredentials
- https://auth0.com/docs/authenticate/protocols/openid-connect-protocol#:~:text=OpenID%20Connect%20(OIDC)%20is%20an,to%20the%20OAuth%202.0%20specifications.
- https://grpc.io/docs/what-is-grpc/introduction/