### PR TITLE
docs: fix the broken link in modeling section

### DIFF
--- a/docs/docs/getting-started/modeling.md
+++ b/docs/docs/getting-started/modeling.md
@@ -445,4 +445,4 @@ We utilize ReBAC and Google Zanzibar to create natural linkage between business 
 
 This example shows almost all aspects of the Permify Schema.
 
-You can check out more schema examples from the [Real World Examples](./examples) section with their detailed examination.
+You can check out more schema examples from the [Real World Examples](https://docs.permify.co/docs/getting-started/examples/) section with their detailed examination.


### PR DESCRIPTION
docs: fix the broken link in modeling section