### PR TITLE
docs: fix broken links for overview and getting started pages

### DIFF
--- a/docs/docs/getting-started/enforcement.md
+++ b/docs/docs/getting-started/enforcement.md
@@ -83,8 +83,8 @@ Permify implements several cache mechanisms in order to achieve low latency in s
 
 Default rate limit is set to 100 requests per second. However, users can adjust this based on their specific needs following our documentation. 
 
-- doc: https://docs.permify.co/docs/reference/configuration
-- algorithm: https://en.wikipedia.org/wiki/Token_bucket
+- [Configuration reference](../../reference/configuration)
+- [Algorithm](https://en.wikipedia.org/wiki/Token_bucket)
 
 ## Need any help ?
 

--- a/docs/docs/getting-started/modeling.md
+++ b/docs/docs/getting-started/modeling.md
@@ -504,7 +504,7 @@ rule check_balance(amount double, balance double) {
 ⛔ If you don’t create the related attribute data, Permify accounts double as `0.0`
 :::
 
-See more details on [Attribute Based Access Control](../use-cases/abac) section to learn our approach on ABAC as well as how it operates in Permify.
+See more details on [Attribute Based Access Control](#attribute-based-permissions-abac) section to learn our approach on ABAC as well as how it operates in Permify.
 
 ## More Advanced Examples
 

--- a/docs/docs/getting-started/sync-data.md
+++ b/docs/docs/getting-started/sync-data.md
@@ -23,7 +23,7 @@ In Permify, the simplest form of relational tuple structured as: `entity # relat
 
 In Permify, these relational tuples represents your authorization data. 
 
-Permify stores your relational tuples (authorization data) in a database you prefer. You can configure the database when running Permify Service with using both [configuration flags](../installation/brew#configuration-flags) or [configuration YAML file](https://github.com/Permify/permify/blob/master/example.config.yaml).
+Permify stores your relational tuples (authorization data) in a database you prefer. You can configure the database when running Permify Service with using both [configuration flags](../../installation/brew#configuration-flags) or [configuration YAML file](https://github.com/Permify/permify/blob/master/example.config.yaml).
 
 Stored relational tuples are queried and utilized in Permify APIs, including the check API, which is an access control check request used to determine whether a user's action is authorized.
 
@@ -33,7 +33,7 @@ As an example; to decide whether a user could view a protected resource, Permify
 
 Relational tuples can be created with an simple API call in runtime, since relations and authorization data's are live instances. Each relational tuple should be created according to its authorization model, [Permify Schema]. 
 
-[Permify Schema]: ../getting-started/modeling
+[Permify Schema]: ../modeling
 
 ![tuple-creation](https://user-images.githubusercontent.com/34595361/186637488-30838a3b-849a-4859-ae4f-d664137bb6ba.png)
 

--- a/docs/docs/permify-overview/infrastructure.md
+++ b/docs/docs/permify-overview/infrastructure.md
@@ -60,7 +60,7 @@ Gathering authorization logic in a central place offers important advantages ove
 
 See the [What is Authorization Service] Section for a detailed explanation of those advantages.
 
-[What is Authorization Service]: ./authorization-service
+[What is Authorization Service]: ../authorization-service
 
 ![load-balancer](https://user-images.githubusercontent.com/34595361/201173835-6f6b67cd-d65b-4239-b695-04ecf1bad5bc.png)
 

--- a/docs/docs/permify-overview/intro.md
+++ b/docs/docs/permify-overview/intro.md
@@ -42,9 +42,9 @@ In Permify, authorization is divided into 3 core aspects; **modeling**, **storin
 - Learn how Permify will [Store Authorization Data] as relations.
 - Perform [Access Checks] anywhere in your stack.
 
-[Model your Authorization]: ../getting-started/modeling
-[Store Authorization Data]: ../getting-started/sync-data
-[Access Checks]: ../getting-started/enforcement
+[Model your Authorization]: ../../getting-started/modeling
+[Store Authorization Data]: ../../getting-started/sync-data
+[Access Checks]: ../../getting-started/enforcement
 
 This document explains how Permify handles these aspects to provide a robust and scalable authorization system for your applications. For the ones that want to try it out and examine it instantly, 
 
@@ -57,7 +57,7 @@ This document explains how Permify handles these aspects to provide a robust and
            <div className="thumb-txt">Use our Playground to test your authorization in a browser. </div>
         </div>
     </a>
-    <a href="https://docs.permify.co/docs/installation/overview">
+    <a href="./installation/overview">
         <div className="btn-thumb">
             <div className="thumbnail">
                  <img src="https://user-images.githubusercontent.com/34595361/199695094-872d50fc-c33b-4d15-ad1d-a3899911a16a.png"/>

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -125,7 +125,7 @@ const config = {
               items: [
                 {
                   label: 'Blog',
-                  to: 'https://www.permify.co/blog',
+                  to: 'https://www.permify.co/post',
                 },
                 {
                   label: 'GitHub',

--- a/docs/versioned_docs/version-0.2.x/permify-overview/intro.md
+++ b/docs/versioned_docs/version-0.2.x/permify-overview/intro.md
@@ -54,7 +54,7 @@ This document explains how Permify handles these aspects to provide a robust and
            <div className="thumb-txt">Use our Playground to test your authorization in a browser. </div>
         </div>
     </a>
-    <a href="https://docs.permify.co/installation/overview">
+    <a href="./installation/overview">
         <div className="btn-thumb">
             <div className="thumbnail">
                  <img src="https://user-images.githubusercontent.com/34595361/199695094-872d50fc-c33b-4d15-ad1d-a3899911a16a.png"/>

--- a/docs/versioned_docs/version-0.3.x/permify-overview/intro.md
+++ b/docs/versioned_docs/version-0.3.x/permify-overview/intro.md
@@ -38,13 +38,13 @@ In Permify, authorization divided into 3 core aspects; **modeling**, **storing a
 - Learn how Permify [Store Authorization Data] as relations.
 - Perform an [Access Checks] anywhere in your stack.
 
-[Model your Authorization]: ../getting-started/modeling
-[Store Authorization Data]: ../getting-started/sync-data
-[Access Checks]: ../getting-started/enforcement
+[Model your Authorization]: ../../getting-started/modeling
+[Store Authorization Data]: ../../getting-started/sync-data
+[Access Checks]: ../../getting-started/enforcement
 
 This document explains how Permify handles these aspects to provide a robust and scalable authorization system for your applications. For the ones that want trying out and examine it instantly, 
 
-**Looking for Permify Managed Service?** See our [pricing plans](https://permify.co/pricing/1).
+**Looking for Permify Managed Service?** See our [pricing plans](https://permify.co/pricing/).
 
 <div className="getting-started-grid">
     <a href="https://play.permify.co/">
@@ -55,7 +55,7 @@ This document explains how Permify handles these aspects to provide a robust and
            <div className="thumb-txt">Use our Playground to test your authorization in a browser. </div>
         </div>
     </a>
-    <a href="https://docs.permify.co/docs/installation/overview">
+    <a href="./installation/overview">
         <div className="btn-thumb">
             <div className="thumbnail">
                  <img src="https://user-images.githubusercontent.com/34595361/199695094-872d50fc-c33b-4d15-ad1d-a3899911a16a.png"/>

--- a/docs/versioned_docs/version-0.4.x/permify-overview/intro.md
+++ b/docs/versioned_docs/version-0.4.x/permify-overview/intro.md
@@ -56,9 +56,9 @@ In Permify, authorization divided into 3 core aspects; **modeling**, **storing a
 - Learn how Permify [Store Authorization Data] as relations.
 - Perform an [Access Checks] anywhere in your stack.
 
-[Model your Authorization]: ../getting-started/modeling
-[Store Authorization Data]: ../getting-started/sync-data
-[Access Checks]: ../getting-started/enforcement
+[Model your Authorization]: ../../getting-started/modeling
+[Store Authorization Data]: ../../getting-started/sync-data
+[Access Checks]: ../../getting-started/enforcement
 
 This document explains how Permify handles these aspects to provide a robust and scalable authorization system for your applications. For the ones that want trying out and examine it instantly, 
 
@@ -71,7 +71,7 @@ This document explains how Permify handles these aspects to provide a robust and
            <div className="thumb-txt">Use our Playground to test your authorization in a browser. </div>
         </div>
     </a>
-    <a href="https://docs.permify.co/docs/installation/overview">
+    <a href="./installation/overview">
         <div className="btn-thumb">
             <div className="thumbnail">
                  <img src="https://user-images.githubusercontent.com/34595361/199695094-872d50fc-c33b-4d15-ad1d-a3899911a16a.png"/>


### PR DESCRIPTION
As I was going through the docs, I kept hitting broken links. This PR fixes some of them, but below is an extensive list:

https://docs.google.com/spreadsheets/d/1Fvob__PD6KSwvrISxpAoLdHf-d7P_youQUDhdrnTw10/edit?usp=sharing

If you are happy with the changes, I can continue on with the list. 

Fixes #806 