### PR TITLE
docs: fix all broken links in non-versioned docs

### DIFF
--- a/docs/docs/api-overview.md
+++ b/docs/docs/api-overview.md
@@ -18,10 +18,10 @@ We structured Permify API in 4 core parts:
 
 Permify exposes its APIs via both [gRPC](https://buf.build/permify/permify/docs/main:base.v1) - with [go] and [nodeJS] client options - and [REST](https://restfulapi.net/).
 
-[PermissionService]: ./api-overview/permission
-[DataService]: ./api-overview/data
-[SchemaService]: ./api-overview/schema
-[TenancyService]: ./api-overview/tenancy
+[PermissionService]: ./permission
+[DataService]: ./data
+[SchemaService]: ./schema
+[TenancyService]: ./tenancy
 [go]: https://github.com/Permify/permify-go
 [nodeJS]: https://github.com/Permify/permify-node
 
@@ -49,7 +49,7 @@ However, since it communicates using standard protocols like gRPC and HTTP, it i
 
 ## Authentication
 
-You can secure APIs with our authentication methods; **Open ID Connect** or **Pre Shared Keys**. They can be configurable with flags or using configuration yaml file. See more details how to enable authentication from [Configuration Options](./reference/configuration)
+You can secure APIs with our authentication methods; **Open ID Connect** or **Pre Shared Keys**. They can be configurable with flags or using configuration yaml file. See more details how to enable authentication from [Configuration Options](../reference/configuration)
 
 To access the endpoints after enabling authentication, it's necessary to provide a Bearer Token for identification. If your using golang or nodeJs client library, an authentication token can be provided via interceptors. You can find details in the clients' documentation.
 

--- a/docs/docs/api-overview/data/write-data.md
+++ b/docs/docs/api-overview/data/write-data.md
@@ -11,8 +11,8 @@ Another example: when one a company executive grant admin role to user (lets say
 
 ![tuple-creation](https://user-images.githubusercontent.com/34595361/186637488-30838a3b-849a-4859-ae4f-d664137bb6ba.png)
 
-[relational tuples]: ../../getting-started/sync-data
-[preferred database]: ../../getting-started/sync-data#where-relational-tuples-used
+[relational tuples]: ../../../getting-started/sync-data
+[preferred database]: ../../../getting-started/sync-data#where-relational-tuples-used
 
 ## Write Request
 

--- a/docs/docs/api-overview/permission/check-api.md
+++ b/docs/docs/api-overview/permission/check-api.md
@@ -10,7 +10,7 @@ In Permify, you can perform two different types access checks,
 
 In this section we'll look at the resource based check request of Permify. You can find subject based access checks in [Entity (Data) Filtering] section.
 
-[Entity (Data) Filtering]: ./lookup-entity
+[Entity (Data) Filtering]: ../lookup-entity
 
 ## Request
 

--- a/docs/docs/api-overview/permission/lookup-entity.md
+++ b/docs/docs/api-overview/permission/lookup-entity.md
@@ -11,8 +11,10 @@ Lookup Entity endpoint lets you ask questions in form of **“Which resources ca
 
 So, we provide 2 separate endpoints for data filtering check request,
 
-- [/v1/permissions/lookup-entity](#lookup-entity)
-- [/v1/permissions/lookup-entity-stream](#lookup-entity-streaming)
+- [Entity Filtering](#entity-filtering)
+  - [Lookup Entity](#lookup-entity)
+  - [How Lookup Operations Evaluated](#how-lookup-operations-evaluated)
+    - [Lookup Entity (Streaming)](#lookup-entity-streaming)
 
 ## Lookup Entity 
 
@@ -26,11 +28,11 @@ In this endpoint you'll get directly the IDs' of the entities that are authorize
 |----------|-------------------|--------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [x]      | tenant_id         | string | -       | identifier of the tenant, if you are not using multi-tenancy (have only one tenant) use pre-inserted tenant `t1` for this field.                                           |
 | [ ]      | schema_version    | string | 8       | Version of the schema                                                                                                                                                      |
-| [ ]      | snap_token        | string | -       | the snap token to avoid stale cache, see more details on [Snap Tokens](../../reference/snap-tokens)                                                                        |
+| [ ]      | snap_token        | string | -       | the snap token to avoid stale cache, see more details on [Snap Tokens](../../../reference/snap-tokens)                                                                        |
 | [x]      | entity_type       | object | -       | type of the  entity. Example: repository”.                                                                                                                                 |
 | [x]      | permission        | string | -       | the action the user wants to perform on the resource                                                                                                                       |
 | [x]      | subject           | object | -       | the user or user set who wants to take the action. It contains type and id of the subject.                                                                                 |
-| [ ]      | context | object | -       | Contextual tuples are relations that can be dynamically added to permission request operations. See more details on [Contextual Tuples](../../reference/contextual-tuples) |
+| [ ]      | context | object | -       | Contextual tuples are relations that can be dynamically added to permission request operations. See more details on [Contextual Tuples](../../../reference/contextual-tuples) |
 
 <Tabs>
 <TabItem value="go" label="Go">
@@ -148,7 +150,7 @@ The difference between this endpoint from direct Lookup Entity is response of th
 | [x]      | entity_type       | object | -       | type of the  entity. Example: repository”.                                                                                                                                 |
 | [x]      | permission        | string | -       | the action the user wants to perform on the resource                                                                                                                       |
 | [x]      | subject           | object | -       | the user or user set who wants to take the action. It contains type and id of the subject.                                                                                 |
-| [ ]      | context | object | -       | Contextual tuples are relations that can be dynamically added to permission request operations. See more details on [Contextual Tuples](../../reference/contextual-tuples) |
+| [ ]      | context | object | -       | Contextual tuples are relations that can be dynamically added to permission request operations. See more details on [Contextual Tuples](../../../reference/contextual-tuples) |
 
 <Tabs>
 <TabItem value="go" label="Go">

--- a/docs/docs/getting-started/enforcement.md
+++ b/docs/docs/getting-started/enforcement.md
@@ -15,10 +15,10 @@ We structured Permify API in 4 core parts:
 
 Permify exposes its APIs via both [gRPC](https://buf.build/permify/permify/docs/main:base.v1) - with [go] and [nodeJS] client options - and [REST](https://restfulapi.net/).
 
-[PermissionService]: ../api-overview/permission
-[DataService]: ../api-overview/data
-[SchemaService]: ../api-overview/schema
-[TenancyService]: ../api-overview/tenancy
+[PermissionService]: ../../api-overview/permission
+[DataService]: ../../api-overview/data
+[SchemaService]: ../../api-overview/schema
+[TenancyService]: ../../api-overview/tenancy
 [go]: https://github.com/Permify/permify-go
 [nodeJS]: https://github.com/Permify/permify-node
 
@@ -75,7 +75,7 @@ Permify designed to answer these authorization questions efficiently and with mi
 - Using its parallel graph engine. 
 - Storing the relationships between resources beforehand in preferred data store, rather than providing these relationships at “check” time.
 - Implementing permission caching to not recompute repeated permission checks, and in memory cache to store authorization schema.
-- Using [Snap Tokens](../reference/snap-tokens) to achieve consistency and high performance in cache.
+- Using [Snap Tokens](../../reference/snap-tokens) to achieve consistency and high performance in cache.
 
 Permify implements several cache mechanisms in order to achieve low latency in scaled distributed systems. See more on the section [Cache Mechanisms](../reference/cache.md) 
 

--- a/docs/docs/installation/brew.md
+++ b/docs/docs/installation/brew.md
@@ -56,7 +56,7 @@ localhost:3476/healthz
 
 You can use our Postman Collection to work with the API. Also see the [Using the API] section for details of core functions.
 
-[Using the API]: ../api-overview/
+[Using the API]: ../../api-overview/
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://www.postman.com/permify-dev/workspace/permify/collection)
 [![View in Swagger](http://jessemillar.github.io/view-in-swagger-button/button.svg)](https://permify.github.io/permify-swagger/)

--- a/docs/docs/installation/overview.md
+++ b/docs/docs/installation/overview.md
@@ -43,7 +43,7 @@ This will start Permify with the default configuration options:
 :::info
 You can examine [Deploy using Docker] section to get more about the configuration options and learn the full integration to run Permify Service from docker container.
 
-[Deploy using Docker]: ../installation/container
+[Deploy using Docker]: ../container
 :::
 
 ### Test your connection
@@ -110,7 +110,7 @@ Lets roll back our example,
 For implementation sake we'll not dive more deep about modeling but you can find more information about modeling on [Modeling Authorization with Permify] section. Also can check out [example use cases] to better understand some basic use cases modeled with Permify Schema. 
 
 [Modeling Authorization with Permify]: ../getting-started/modeling
-[example use cases]: ../use-cases/simple-rbac
+[example use cases]: ../../use-cases/simple-rbac
 :::
 
 ### Configuring Schema via API 
@@ -190,7 +190,7 @@ In ideal production usage Permify stores your authorization data in a database y
 
 But in this tutorial Permify Service running default configurations on local, so authorization data will be stored in memory. You can find more detailed explanation how Permify stores authorization data in [Managing Authorization Data] section.
 
-[Managing Authorization Data]: ../getting-started/sync-data
+[Managing Authorization Data]: ../../getting-started/sync-data
 :::
 
 ## Perform Access Check
@@ -199,8 +199,8 @@ Finally we're ready to control authorization. Access decision results computed a
 
 Lets get back to our example and perform an example access check via [Check API]. We want to check whether an specific user has an access to view files in a organization.
 
-[Check API]: ../api-overview/permission/check-api
-[Permify Schema]: ../getting-started/modeling
+[Check API]: ../../api-overview/permission/check-api
+[Permify Schema]: ../../getting-started/modeling
 
 #### Example HTTP Request: 
 

--- a/docs/docs/playground.md
+++ b/docs/docs/playground.md
@@ -117,7 +117,7 @@ which `‍parent.admin`‍ indicates admin in the organization that repository b
 :::info Create More Advanced Scenarios
 For simplicity, we've created a basic scenario. However, you can create more advanced scenarios using our validation YAML structure.
 
-To learn how to use this syntax for complex scenarios, refer to the [Creating Test Scenarios](./getting-started/testing#creating-test-scenarios) section in [Testing & Validation](./getting-started/testing.md) page.
+To learn how to use this syntax for complex scenarios, refer to the [Creating Test Scenarios](../getting-started/testing#creating-test-scenarios) section in [Testing & Validation](./getting-started/testing.md) page.
 :::
 
 Let's click the Run button to execute our scenario. The scenario name should turn green once the scenario result is confirmed as correct.

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -484,7 +484,7 @@ A consistent hashing ring ensures data distribution that minimizes reorganizatio
 
 [jaeger]: https://www.jaegertracing.io/
 
-[otlp]: (https://opentelemetry.io/)
+[otlp]: https://opentelemetry.io/
 
 [zipkin]: https://zipkin.io/
 

--- a/docs/docs/reference/glossary.md
+++ b/docs/docs/reference/glossary.md
@@ -32,7 +32,7 @@ These ACLs called relational tuples: the underlying data form that represents ob
 
 ## Permission Database 
 
-Permify stores your relational tuples (authorization data) in a database you prefer. You can configure it when running Permify Service with using both [configuration flags](../installation/brew#configuration-flags)  or [configuration YAML file](https://github.com/Permify/permify/blob/master/example.config.yaml).
+Permify stores your relational tuples (authorization data) in a database you prefer. You can configure it when running Permify Service with using both [configuration flags](../../installation/brew#configuration-flags)  or [configuration YAML file](https://github.com/Permify/permify/blob/master/example.config.yaml).
 
 ## Relationship Based Access Control (ReBAC)
 

--- a/docs/docs/reference/snap-tokens.md
+++ b/docs/docs/reference/snap-tokens.md
@@ -39,14 +39,13 @@ Then this snap token can be used in endpoints. For example it can be used in acc
 }
 ```
 
-[Write API]: ../api-overview/relationship/write-relationships
-[Check API]: ../api-overview/permission/check-api
+[Write API]: ../../api-overview/data/write-data/
+[Check API]: ../../api-overview/permission/check-api
 
 #### All endpoints that used snap token 
 
-- [Write API](../api-overview/relationship/write-relationships) 
-- [Check API](../api-overview/permission/check-api)
-- [Expand API](../api-overview/permission/expand-api)
+- [Write API](../../api-overview/data/write-data/)
+- [Expand API](../../api-overview/permission/expand-api)
 
 
 ## More on Cache Mechanism 

--- a/docs/docs/use-cases/custom-roles.md
+++ b/docs/docs/use-cases/custom-roles.md
@@ -3,7 +3,7 @@
 
 This document highlights a solution for custom roles with the [Permify Schema]. In this tutorial, we will create custom **admin** and **member** roles in a project. Then set the permissions of these roles according to their capabilities on the dashboard and tasks.
 
-[Permify Schema]: ../getting-started/modeling
+[Permify Schema]: ../../getting-started/modeling
 
 Before we get started, here's the final schema that we will create in this tutorial.
 

--- a/docs/docs/use-cases/multi-tenancy.md
+++ b/docs/docs/use-cases/multi-tenancy.md
@@ -17,9 +17,14 @@ For the users that don't have/need multi-tenancy in their authorization structur
 
 Several things changed when we moved to tenant based infrastructure, these are:
 
-* [API endpoints now have Tenant ID field](#api-endpoints-now-have-tenant-id-field)
-* [Added Tenancy Service](#added-tenancy-service)
-* [Permission Database tables and tenant id column](#permission-database-tenancy-table-and-tenant-id-column)
+- [Multi Tenancy on Permify](#multi-tenancy-on-permify)
+  - [API endpoints now have Tenant ID field](#api-endpoints-now-have-tenant-id-field)
+    - [Check API](#check-api)
+  - [Added Tenancy Service](#added-tenancy-service)
+  - [Permission Database Tenancy Table and Tenant Id column](#permission-database-tenancy-table-and-tenant-id-column)
+    - [Tenant Table](#tenant-table)
+    - [Tenant ID Column](#tenant-id-column)
+- [Need any help ?](#need-any-help-)
 
 ### API endpoints now have Tenant ID field 
 
@@ -116,7 +121,7 @@ Users that come from version 0.2.x and users that have a single tenant can enter
 
 ### Added Tenancy Service
 
-To manage tenants we have added a Tenancy service; you can create, delete and list tenants. See the [Tenancy Service](../api-overview/tenancy) in Using The API section.
+To manage tenants we have added a Tenancy service; you can create, delete and list tenants. See the [Tenancy Service](../../api-overview/tenancy) in Using The API section.
 
 ### Permission Database Tenancy Table and Tenant Id column
 

--- a/docs/src/components/Case/CaseList.jsx
+++ b/docs/src/components/Case/CaseList.jsx
@@ -9,31 +9,31 @@ export const CaseList = () => {
       id:1,
       title:"Role Based Access Control (RBAC)",
       description: "Want to implement role to your application ? Define an entity and manage your roles throught your applications.",
-      link: "./use-cases/simple-rbac"
+      link: "./simple-rbac"
     },
     {
       id:2,
       title:"Attribute Based Access Control (ABAC)",
       description: "Grant access what based on specific characteristics or attributes.",
-      link: "./use-cases/abac"
+      link: "./abac"
     },
     {
       id:3,
       title:"Relationship Based Access Control (ReBAC)",
       description: "Define permissions based on the relationships between resources and subjects in your system",
-      link: "./use-cases/rebac"
+      link: "./rebac"
     },
     {
       id:4,
       title:"Custom Roles",
       description: "Assign specific permissions to users based on the custom roles that they are assigned within the system.",
-      link: "./use-cases/custom-roles"
+      link: "./custom-roles"
     },
     {
       id:5,
       title:"Multi Tenancy",
       description: "Create custom authorization schema and relation tuples for the different tenants and manage them in a single place.",
-      link:  "./use-cases/multi-tenancy"
+      link:  "./multi-tenancy"
     },
   ]
 


### PR DESCRIPTION
This continues on from #848 to fix broken links in docs site. This PR addresses all broken links in the non-versioned docs.

Full list: https://docs.google.com/spreadsheets/d/1Fvob__PD6KSwvrISxpAoLdHf-d7P_youQUDhdrnTw10/edit?usp=sharing