### PR TITLE
docs: fix broken links for versioned docs (v0.3.x)

### DIFF
--- a/docs/versioned_docs/version-0.3.x/api-overview.md
+++ b/docs/versioned_docs/version-0.3.x/api-overview.md
@@ -18,10 +18,10 @@ We structured Permify API in 3 core parts:
 
 Permify exposes its APIs via both [gRPC](https://buf.build/permify/permify/docs/main:base.v1) - with [go] and [nodeJS] client options - and [REST](https://restfulapi.net/). 
 
-[PermissionService]: ./api-overview/permission
-[RelationshipService]: ./api-overview/relationship
-[SchemaService]: ./api-overview/schema
-[TenancyService]: ./api-overview/tenancy
+[PermissionService]: ./permission
+[RelationshipService]: ./relationship
+[SchemaService]: ./schema
+[TenancyService]: ./tenancy
 
 [go]: https://github.com/Permify/permify-go
 [nodeJS]: https://github.com/Permify/permify-node
@@ -42,7 +42,7 @@ Permify exposes its APIs via both [gRPC](https://buf.build/permify/permify/docs/
 
 ## Authentication
 
-You can secure APIs with our authentication methods; **Open ID Connect** or **Pre Shared Keys**. They can be configurable with flags or using configuration yaml file. See more details how to enable authentication from [Configuration Options](./reference/configuration)
+You can secure APIs with our authentication methods; **Open ID Connect** or **Pre Shared Keys**. They can be configurable with flags or using configuration yaml file. See more details how to enable authentication from [Configuration Options](../reference/configuration)
 
 To access the endpoints after enabling authentication, it's necessary to provide a Bearer Token for identification. If your using golang or nodeJs client library, an authentication token can be provided via interceptors. You can find details in the clients' documentation.
 

--- a/docs/versioned_docs/version-0.3.x/api-overview/permission/check-api.md
+++ b/docs/versioned_docs/version-0.3.x/api-overview/permission/check-api.md
@@ -10,7 +10,7 @@ In Permify, you can perform two different types access checks,
 
 In this section we'll look at the resource based check request of Permify. You can find subject based access checks in [Check Entities' Permissions] section.
 
-[Check Entities' Permissions]: ./lookup-entity
+[Check Entities' Permissions]: ../lookup-entity
 
 ## Request
 
@@ -20,7 +20,7 @@ In this section we'll look at the resource based check request of Permify. You c
 |----------|----------|---------|---------|-------------------------------------------------------------------------------------------|
 | [x]   | tenant_id | string | - | identifier of the tenant, if you are not using multi-tenancy (have only one tenant) use pre-inserted tenant `t1` for this field.
 | [ ]   | schema_version | string | 8 | Version of the schema |
-| [ ]   | snap_token | string | - | the snap token to avoid stale cache, see more details on [Snap Tokens](../../reference/snap-tokens) |
+| [ ]   | snap_token | string | - | the snap token to avoid stale cache, see more details on [Snap Tokens](../../../reference/snap-tokens) |
 | [x]   | entity | object | - | contains entity type and id of the entity. Example: repository:1”.
 | [x]   | permission | string | - | the action the user wants to perform on the resource |
 | [x]   | subject | object | - | the user or user set who wants to take the action. It contains type and id of the subject.  |
@@ -123,7 +123,7 @@ curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/permission
 
 Answering access checks is accomplished within Permify using a basic graph walking mechanism. See how [access decisions evaluated] in Permify.
 
-[access decisions evaluated]: ../../getting-started/enforcement#how-access-decisions-evaluated
+[access decisions evaluated]: ../../../getting-started/enforcement#how-access-decisions-evaluated
 
 ## Need any help ?
 

--- a/docs/versioned_docs/version-0.3.x/api-overview/relationship/write-relationships.md
+++ b/docs/versioned_docs/version-0.3.x/api-overview/relationship/write-relationships.md
@@ -11,8 +11,8 @@ Another example: when one a company executive grant admin role to user (lets say
 
 ![tuple-creation](https://user-images.githubusercontent.com/34595361/186637488-30838a3b-849a-4859-ae4f-d664137bb6ba.png)
 
-[relational tuples]: ../../getting-started/sync-data
-[writeDB]: ../../getting-started/sync-data#where-relational-tuples-used
+[relational tuples]: ../../../getting-started/sync-data
+[writeDB]: ../../../getting-started/sync-data#where-relational-tuples-used
 
 ## Request
 
@@ -120,7 +120,7 @@ curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/relationsh
 
 You can store that snap token alongside with the resource in your relational database, then use it used in endpoints to get fresh results from the API's. For example it can be used in access control check with sending via `snap_token` field to ensure getting check result as fresh as previous request.
 
-See more details on what is [Snap Tokens](../../reference/snap-tokens) and how its avoiding stale cache.
+See more details on what is [Snap Tokens](../../../reference/snap-tokens) and how its avoiding stale cache.
 
 ## Suggested Workflow 
 

--- a/docs/versioned_docs/version-0.3.x/getting-started/enforcement.md
+++ b/docs/versioned_docs/version-0.3.x/getting-started/enforcement.md
@@ -19,7 +19,7 @@ Permify designed to answer these authorization questions efficiently and with mi
 - Using its parallel graph engine. 
 - Storing the relationships between resources beforehand in Permify data store: [writeDB], rather than providing these relationships at “check” time.
 - Implementing permission caching to not recompute repeated permission checks, and in memory cache to store authorization schema.
-- Using [Snap Tokens](../reference/snap-tokens) to achieve consistency and high performance in cache.
+- Using [Snap Tokens](../../reference/snap-tokens) to achieve consistency and high performance in cache.
 
 Performance and availability of the API calls - especially access checks - are crucial for us and we're ongoingly improving and testing it with various methods.   
 
@@ -41,8 +41,8 @@ Permify Engine to compute access decision in 2 steps,
 
 Let's turn back to above authorization question ( ***"Can the user 3 edit document 12 ?"*** ) to better understand how decision evaluation works. 
 
-[relational tuples]: ../getting-started/sync-data
-[Permify Schema]:  ../getting-started/modeling
+[relational tuples]: ../../getting-started/sync-data
+[Permify Schema]:  ../../getting-started/modeling
 
 When Permify Engine receives this question it directly looks up to authorization model to find document `‍edit` action. Let's say we have a model as follows
 

--- a/docs/versioned_docs/version-0.3.x/getting-started/modeling.md
+++ b/docs/versioned_docs/version-0.3.x/getting-started/modeling.md
@@ -284,4 +284,4 @@ entity repository {
 
 This example shows almost all aspects of the Permify Schema. 
 
-You can check out more schema examples from the [Real World Examples](./examples) section with their detailed examination.
+You can check out more schema examples from the [Real World Examples](../examples) section with their detailed examination.

--- a/docs/versioned_docs/version-0.3.x/getting-started/sync-data.md
+++ b/docs/versioned_docs/version-0.3.x/getting-started/sync-data.md
@@ -25,7 +25,7 @@ In Permify, the simplest form of relational tuple structured as: `entity # relat
 
 In Permify, these relational tuples represents your authorization data. 
 
-Permify stores your relational tuples (authorization data) in a database you prefer. You can configure the database when running Permify Service with using both [configuration flags](../installation/brew#configuration-flags) or [configuration YAML file](https://github.com/Permify/permify/blob/master/example.config.yaml).
+Permify stores your relational tuples (authorization data) in a database you prefer. You can configure the database when running Permify Service with using both [configuration flags](../../installation/brew#configuration-flags) or [configuration YAML file](https://github.com/Permify/permify/blob/master/example.config.yaml).
 
 Stored relational tuples are queried and utilized in Permify APIs, including the check API, which is an access control check request used to determine whether a user's action is authorized.
 
@@ -36,7 +36,7 @@ As an example; to decide whether a user could view a protected resource, Permify
 
 Relational tuples can be created with an simple API call in runtime, since relations and authorization data's are live instances. Each relational tuple should be created according to its authorization model, [Permify Schema]. 
 
-[Permify Schema]: ../getting-started/modeling
+[Permify Schema]: ../../getting-started/modeling
 
 ![tuple-creation](https://user-images.githubusercontent.com/34595361/186637488-30838a3b-849a-4859-ae4f-d664137bb6ba.png)
 

--- a/docs/versioned_docs/version-0.3.x/installation/brew.md
+++ b/docs/versioned_docs/version-0.3.x/installation/brew.md
@@ -42,7 +42,7 @@ localhost:3476/healthz
 
 You can use our Postman Collection to work with the API. Also see the [Using the API] section for details of core functions.
 
-[Using the API]: ../api-overview/
+[Using the API]: ../../api-overview/
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://www.postman.com/permify-dev/workspace/permify/collection)
 [![View in Swagger](http://jessemillar.github.io/view-in-swagger-button/button.svg)](https://permify.github.io/permify-swagger/)

--- a/docs/versioned_docs/version-0.3.x/installation/overview.md
+++ b/docs/versioned_docs/version-0.3.x/installation/overview.md
@@ -37,7 +37,7 @@ This will start Permify with the default configuration options:
 :::info
 You can examine [Deploy using Docker] section to get more about the configuration options and learn the full integration to run Permify Service from docker container.
 
-[Deploy using Docker]: ../installation/container
+[Deploy using Docker]: ../container
 :::
 
 ### Test your connection
@@ -50,7 +50,7 @@ localhost:3476/healthz
 
 You can use our Postman Collection to work with the API. Also see the [Using the API] section for details of core endpoints.
 
-[Using the API]: ../api-overview.md
+[Using the API]: ../api-overview
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://www.postman.com/permify-dev/workspace/permify/collection)
 [![View in Swagger](http://jessemillar.github.io/view-in-swagger-button/button.svg)](https://permify.github.io/permify-swagger/)
@@ -103,8 +103,8 @@ Lets roll back our example,
 :::info
 For implementation sake we'll not dive more deep about modeling but you can find more information about modeling on [Modeling Authorization with Permify] section. Also can check out [example use cases] to better understand some basic use cases modeled with Permify Schema. 
 
-[Modeling Authorization with Permify]: ../getting-started/modeling
-[example use cases]: ../use-cases/simple-rbac
+[Modeling Authorization with Permify]: ../../getting-started/modeling
+[example use cases]: ../../use-cases/simple-rbac
 :::
 
 ### Configuring Schema via API 
@@ -184,7 +184,7 @@ In ideal production usage Permify stores your authorization data in a database y
 
 But in this tutorial Permify Service running default configurations on local, so authorization data will be stored in memory. You can find more detailed explanation how Permify stores authorization data in [Managing Authorization Data] section.
 
-[Managing Authorization Data]: ../getting-started/sync-data
+[Managing Authorization Data]: ../../getting-started/sync-data
 :::
 
 ## Perform Access Check
@@ -193,8 +193,8 @@ Finally we're ready to control authorization. Access decision results computed a
 
 Lets get back to our example and perform an example access check via [Check API]. We want to check whether an specific user has an access to view files in a organization.
 
-[Check API]: ../api-overview/permission/check-api
-[Permify Schema]: ../getting-started/modeling
+[Check API]: ../../api-overview/permission/check-api
+[Permify Schema]: ../../getting-started/modeling
 
 #### Example HTTP Request: 
 

--- a/docs/versioned_docs/version-0.3.x/migrating.md
+++ b/docs/versioned_docs/version-0.3.x/migrating.md
@@ -116,11 +116,11 @@ curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/permission
 </TabItem>
 </Tabs>
 
-Users that come from version 0.2.x and users that have a single tenant can enter **t1** as tenant id. See changes on the other endpoints from [API Overview Section](./api-overview/).
+Users that come from version 0.2.x and users that have a single tenant can enter **t1** as tenant id. See changes on the other endpoints from [API Overview Section](../api-overview/).
 
 ### Added Tenancy Service
 
-To manage tenants we have added a Tenancy service; you can create, delete and list tenants accordingly. See the [Tenancy Service](./api-overview/tenancy/) on Using The API section.
+To manage tenants we have added a Tenancy service; you can create, delete and list tenants accordingly. See the [Tenancy Service](../api-overview/tenancy/) on Using The API section.
 
 ### WriteDB tenancy table and tenant id column
 

--- a/docs/versioned_docs/version-0.3.x/permify-overview/infrastructure.md
+++ b/docs/versioned_docs/version-0.3.x/permify-overview/infrastructure.md
@@ -33,7 +33,7 @@ There are two main deployment patterns that you can follow, integrate Permify in
 
 Permify can be deployed as a sole service that abstracts authorization logic from core applications and behaves as a single source of truth for authorization. Gathering authorization logic in a central place offers important advantages over maintaining separate access control mechanisms for individual applications. See the [What is Authorization Service] Section for a detailed explanation of those advantages.
 
-[What is Authorization Service]: ./authorization-service
+[What is Authorization Service]: ../authorization-service
 
 ![load-balancer](https://user-images.githubusercontent.com/34595361/201173835-6f6b67cd-d65b-4239-b695-04ecf1bad5bc.png)
 

--- a/docs/versioned_docs/version-0.3.x/reference/glossary.md
+++ b/docs/versioned_docs/version-0.3.x/reference/glossary.md
@@ -32,7 +32,7 @@ These ACLs called relational tuples: the underlying data form that represents ob
 
 ## Write Database - WriteDB
 
-Permify stores your relational tuples (authorization data) in **WriteDB**. You can configure it **WriteDB** when running Permify Service with using both [configuration flags](../installation/brew#configuration-flags)  or [configuration YAML file](https://github.com/Permify/permify/blob/master/example.config.yaml).
+Permify stores your relational tuples (authorization data) in **WriteDB**. You can configure it **WriteDB** when running Permify Service with using both [configuration flags](../../installation/brew#configuration-flags)  or [configuration YAML file](https://github.com/Permify/permify/blob/master/example.config.yaml).
 
 ## Relationship Based Access Control (ReBAC)
 

--- a/docs/versioned_docs/version-0.3.x/reference/snap-tokens.md
+++ b/docs/versioned_docs/version-0.3.x/reference/snap-tokens.md
@@ -39,12 +39,12 @@ Then this snap token can be used in endpoints. For example it can be used in acc
 }
 ```
 
-[Write API]: ../api-overview/relationship/write-relationships
-[Check API]: ../api-overview/permission/check-api
+[Write API]: ../../api-overview/relationship/write-relationships
+[Check API]: ../../api-overview/permission/check-api
 
 #### All endpoints that used snap token 
 
-- [Write API](../api-overview/relationship/write-relationships) 
-- [Check API](../api-overview/permission/check-api)
-- [Expand API](../api-overview/permission/expand-api) 
-- [Schema Lookup](../api-overview/permission/schema-lookup)
+- [Write API](../../api-overview/relationship/write-relationships) 
+- [Check API](../../api-overview/permission/check-api)
+- [Expand API](../../api-overview/permission/expand-api) 
+- [Schema Lookup](../../api-overview/permission/schema-lookup)

--- a/docs/versioned_docs/version-0.3.x/use-cases/simple-rbac.md
+++ b/docs/versioned_docs/version-0.3.x/use-cases/simple-rbac.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 Want to implement role and permissions to your application ? Permify fully covers you at that point. Below example shows how to model simple role based access control for organizational roles and permissions with our authorization language, [Permify Schema].
 
-[Permify Schema]: ../getting-started/modeling
+[Permify Schema]: ../../getting-started/modeling
 
 Before we get started, here's the final schema that we will create in this tutorial.
 


### PR DESCRIPTION
This PR continues on fixing broken links in the docs website, this time all broken links for v0.3.x

Full list: https://docs.google.com/spreadsheets/d/1Fvob__PD6KSwvrISxpAoLdHf-d7P_youQUDhdrnTw10/edit?usp=sharing