### PR TITLE
Added "Edit this page" link to docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -39,6 +39,9 @@ const config = {
               label: '0.6.x',
             },
           },
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/Permify/permify/master/editor/docs/docs/${docPath}`
+          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/Permify/permify/master/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb