### PR TITLE
feat(coverage): validating before running coverage.

### DIFF
--- a/pkg/cmd/coverage.go
+++ b/pkg/cmd/coverage.go
@@ -71,6 +71,15 @@ func coverage() func(cmd *cobra.Command, args []string) error {
 
 		s.Schema = loaded
 
+		color.Notice.Println("initiating validation... 🚀")
+		validator := validate()
+		err = validator(cmd, args)
+		if err != nil {
+			color.Danger.Println("failed to validate given file\n")
+			color.Danger.Println("FAILED")
+			return err
+		}
+
 		color.Notice.Println("initiating coverage analysis... 🚀")
 
 		schemaCoverageInfo := cov.Run(*s)


### PR DESCRIPTION
fixes: #811

Description:
- calls validation before begining any computation on coverage.
- returns error if failed.