### PR TITLE
[playground] update docs for playground local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,9 @@ clean: ## Remove temporary and generated files
 	rm -f coverage.out coverage.html
 
 .PHONY: wasm-build
-wasm-build: ## Build wasm
+wasm-build: ## Build wasm & place it in playground
 	cd ./pkg/development/wasm && GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o main.wasm && wasm-opt main.wasm --enable-bulk-memory -Oz -o play.wasm
+	cp ./pkg/development/wasm/play.wasm ./playground/public/play.wasm
 
 .PHONY: release
 release: format test security-scan clean ## Prepare for release

--- a/playground/README.md
+++ b/playground/README.md
@@ -3,6 +3,24 @@
 This directory contains a Permify playground. You can check out running version of [Playground](https://play.permify.co).
 Playground works with [webassembly](https://webassembly.org). You can find the source code of playground in [/pkg/development/wasm](/pkg/development/wasm)
 
+## How to run playground locally
+First, you need to install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/). Then, you will need to build the `play.wasm` file. You can do it by running the following command in the root directory:
+
+```bash
+make wasm-build
+```
+
+Then, you can run the playground by running the following command in the playground directory:
+
+```bash
+yarn start
+```
+or the following command in the root directory:
+
+```bash
+make serve-playground
+```
+
 ## Available Scripts
 
 In the playground directory, you can run:


### PR DESCRIPTION
This updates the readme for playground to make it clearer on how to get the playground working locally as it wasn't very straight forward when I had to work on it.