### PR TITLE
feat(tracing): Add meter-insecure, meter-urlpath, tracer-url-path configuration option

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -350,6 +350,7 @@ os, arch.
 | meter-enabled      | PERMIFY_METER_ENABLED   | boolean      |
 | meter-exporter     | PERMIFY_METER_EXPORTER  | string       |
 | meter-endpoint     | PERMIFY_METER_ENDPOINT  | string       |
+| meter-insecure     | PERMIFY_METER_INSECURE  | string       |
 
 </p>
 </details>

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -304,6 +304,7 @@ authorization when using Permify.
 | [x]      | exporter | -       | Tracer exporter, the options are `jaeger`, `otlp`, `signoz`, and `zipkin`. |
 | [x]      | endpoint | -       | export uri for tracing data.                                               |
 | [ ]      | enabled  | false   | switch option for tracing.                                                 |
+| [ ]      | urlpath  |         | allows one to override the default URL path for otlp, used for sending traces. If unset, default ("/v1/traces") will be used.                                              |
 | [ ]      | insecure | false   | Whether to use HTTP instead of HTTPs for exporting the traces.             |
 
 #### ENV
@@ -313,6 +314,7 @@ authorization when using Permify.
 | tracer-enabled       | PERMIFY_TRACER_ENABLED        | boolean      |
 | tracer-exporter      | PERMIFY_TRACER_EXPORTER       | string       |
 | tracer-endpoint      | PERMIFY_TRACER_ENDPOINT       | string       |
+| tracer-urlpath       | PERMIFY_TRACER_URL_PATH       | string       |
 | tracer-insecure      | PERMIFY_TRACER_INSECURE       | boolean      |
 
 </p>

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -295,6 +295,8 @@ authorization when using Permify.
 |   ├── exporter
 |   ├── endpoint
 |   ├── enabled
+|   ├── insecure
+|   ├── urlpath
 ```
 
 #### Glossary
@@ -335,6 +337,8 @@ os, arch.
 |   ├── exporter
 |   ├── endpoint
 |   ├── enabled
+|   ├── insecure
+|   ├── urlpath
 ```
 
 #### Glossary
@@ -352,6 +356,7 @@ os, arch.
 | meter-enabled      | PERMIFY_METER_ENABLED   | boolean      |
 | meter-exporter     | PERMIFY_METER_EXPORTER  | string       |
 | meter-endpoint     | PERMIFY_METER_ENDPOINT  | string       |
+| meter-urlpath      | PERMIFY_METER_URL_PATH       | string       |
 | meter-insecure     | PERMIFY_METER_INSECURE  | string       |
 
 </p>

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -357,7 +357,7 @@ os, arch.
 | meter-exporter     | PERMIFY_METER_EXPORTER  | string       |
 | meter-endpoint     | PERMIFY_METER_ENDPOINT  | string       |
 | meter-urlpath      | PERMIFY_METER_URL_PATH       | string       |
-| meter-insecure     | PERMIFY_METER_INSECURE  | string       |
+| meter-insecure     | PERMIFY_METER_INSECURE  | boolean       |
 
 </p>
 </details>

--- a/docs/docs/reference/tracing.md
+++ b/docs/docs/reference/tracing.md
@@ -25,7 +25,7 @@ tracer:
 - ***endpoint***: export url for tracing data.
 - ***disabled***: switch option for tracing.
 - ***insecure***: configures the exporter to connect to the collcetor using HTTP instead of HTTPS. This configuration is relevant only for `signoz` and `otlp`.
-
+- ***urlpath***: allows one to override the default URL path used for sending traces. If unset, default ("/v1/traces") will be used. This configuration is relevant only for `otlp`.
 **Example YAML configuration file**
 
 ```yaml

--- a/docs/docs/reference/tracing.md
+++ b/docs/docs/reference/tracing.md
@@ -26,6 +26,7 @@ tracer:
 - ***disabled***: switch option for tracing.
 - ***insecure***: configures the exporter to connect to the collcetor using HTTP instead of HTTPS. This configuration is relevant only for `signoz` and `otlp`.
 - ***urlpath***: allows one to override the default URL path used for sending traces. If unset, default ("/v1/traces") will be used. This configuration is relevant only for `otlp`.
+
 **Example YAML configuration file**
 
 ```yaml

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -65,7 +65,7 @@ service:
     cache:
       number_of_counters: 10_000
       max_cost: 10MiB
-  relationship:
+  data:
 
 # The database section specifies the database engine and connection settings,
 # including the URI for the database, whether or not to auto-migrate the database,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,7 @@ type (
 		Exporter string `mapstructure:"exporter"` // Exporter for tracing data
 		Endpoint string `mapstructure:"endpoint"` // Endpoint for the tracing exporter
 		Insecure bool   `mapstructure:"insecure"` // Connect to the collector using the HTTP scheme, instead of HTTPS.
+		URLPath  string `mapstructure:"path"`     // Path for the tracing exporter, if not defined /v1/trace will be used
 	}
 
 	// Meter contains configuration for metrics collection and reporting.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,7 @@ type (
 		Enabled  bool   `mapstructure:"enabled"`  // Whether metrics collection is enabled
 		Exporter string `mapstructure:"exporter"` // Exporter for metrics data
 		Endpoint string `mapstructure:"endpoint"` // Endpoint for the metrics exporter
+		Insecure bool   `mapstructure:"insecure"` // Connect to the collector using the HTTP scheme, instead of HTTPS.
 	}
 
 	// Service contains configuration for various service-level features.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,6 +99,7 @@ type (
 		Exporter string `mapstructure:"exporter"` // Exporter for metrics data
 		Endpoint string `mapstructure:"endpoint"` // Endpoint for the metrics exporter
 		Insecure bool   `mapstructure:"insecure"` // Connect to the collector using the HTTP scheme, instead of HTTPS.
+		URLPath  string `mapstructure:"path"`     // Path for the metrics exporter, if not defined /v1/metrics will be used
 	}
 
 	// Service contains configuration for various service-level features.

--- a/pkg/cmd/flags/serve.go
+++ b/pkg/cmd/flags/serve.go
@@ -218,6 +218,13 @@ func RegisterServeFlags(cmd *cobra.Command) {
 	if err = viper.BindEnv("tracer.insecure", "PERMIFY_TRACER_INSECURE"); err != nil {
 		panic(err)
 	}
+	flags.String("tracer-urlpath", conf.Tracer.URLPath, "allow to set url path for otlp exporter")
+	if err = viper.BindPFlag("tracer.insecure", flags.Lookup("tracer-urlpath")); err != nil {
+		panic(err)
+	}
+	if err = viper.BindEnv("tracer.urlpath", "PERMIFY_TRACER_URL_PATH"); err != nil {
+		panic(err)
+	}
 
 	// METER
 	flags.Bool("meter-enabled", conf.Meter.Enabled, "switch option for metric")

--- a/pkg/cmd/flags/serve.go
+++ b/pkg/cmd/flags/serve.go
@@ -218,6 +218,7 @@ func RegisterServeFlags(cmd *cobra.Command) {
 	if err = viper.BindEnv("tracer.insecure", "PERMIFY_TRACER_INSECURE"); err != nil {
 		panic(err)
 	}
+
 	flags.String("tracer-urlpath", conf.Tracer.URLPath, "allow to set url path for otlp exporter")
 	if err = viper.BindPFlag("tracer.urlpath", flags.Lookup("tracer-urlpath")); err != nil {
 		panic(err)
@@ -250,11 +251,20 @@ func RegisterServeFlags(cmd *cobra.Command) {
 	if err = viper.BindEnv("meter.endpoint", "PERMIFY_METER_ENDPOINT"); err != nil {
 		panic(err)
 	}
+
 	flags.Bool("meter-insecure", conf.Meter.Insecure, "use https or http for metric data")
 	if err = viper.BindPFlag("meter.insecure", flags.Lookup("meter-insecure")); err != nil {
 		panic(err)
 	}
 	if err = viper.BindEnv("meter.insecure", "PERMIFY_METER_INSECURE"); err != nil {
+		panic(err)
+	}
+
+	flags.String("meter-urlpath", conf.Meter.URLPath, "allow to set url path for otlp exporter")
+	if err = viper.BindPFlag("meter.urlpath", flags.Lookup("meter-urlpath")); err != nil {
+		panic(err)
+	}
+	if err = viper.BindEnv("meter.urlpath", "PERMIFY_METER_URL_PATH"); err != nil {
 		panic(err)
 	}
 

--- a/pkg/cmd/flags/serve.go
+++ b/pkg/cmd/flags/serve.go
@@ -219,7 +219,7 @@ func RegisterServeFlags(cmd *cobra.Command) {
 		panic(err)
 	}
 	flags.String("tracer-urlpath", conf.Tracer.URLPath, "allow to set url path for otlp exporter")
-	if err = viper.BindPFlag("tracer.insecure", flags.Lookup("tracer-urlpath")); err != nil {
+	if err = viper.BindPFlag("tracer.urlpath", flags.Lookup("tracer-urlpath")); err != nil {
 		panic(err)
 	}
 	if err = viper.BindEnv("tracer.urlpath", "PERMIFY_TRACER_URL_PATH"); err != nil {

--- a/pkg/cmd/flags/serve.go
+++ b/pkg/cmd/flags/serve.go
@@ -211,6 +211,13 @@ func RegisterServeFlags(cmd *cobra.Command) {
 	if err = viper.BindEnv("tracer.endpoint", "PERMIFY_TRACER_ENDPOINT"); err != nil {
 		panic(err)
 	}
+	flags.Bool("tracer-insecure", conf.Tracer.Insecure, "use https or http for tracer data, only used for otlp exporter or signoz")
+	if err = viper.BindPFlag("tracer.insecure", flags.Lookup("tracer-insecure")); err != nil {
+		panic(err)
+	}
+	if err = viper.BindEnv("tracer.insecure", "PERMIFY_TRACER_INSECURE"); err != nil {
+		panic(err)
+	}
 
 	// METER
 	flags.Bool("meter-enabled", conf.Meter.Enabled, "switch option for metric")
@@ -234,6 +241,13 @@ func RegisterServeFlags(cmd *cobra.Command) {
 		panic(err)
 	}
 	if err = viper.BindEnv("meter.endpoint", "PERMIFY_METER_ENDPOINT"); err != nil {
+		panic(err)
+	}
+	flags.Bool("meter-insecure", conf.Meter.Insecure, "use https or http for metric data")
+	if err = viper.BindPFlag("meter.insecure", flags.Lookup("meter-insecure")); err != nil {
+		panic(err)
+	}
+	if err = viper.BindEnv("meter.insecure", "PERMIFY_METER_INSECURE"); err != nil {
 		panic(err)
 	}
 

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -178,7 +178,11 @@ func serve() func(cmd *cobra.Command, args []string) error {
 		meter := telemetry.NewNoopMeter()
 		if cfg.Meter.Enabled {
 			var exporter metric.Exporter
-			exporter, err = meterexporters.ExporterFactory(cfg.Meter.Exporter, cfg.Meter.Endpoint)
+			exporter, err = meterexporters.ExporterFactory(
+				cfg.Meter.Exporter,
+				cfg.Meter.Endpoint,
+				cfg.Meter.Insecure,
+			)
 			if err != nil {
 				slog.Error(err.Error())
 			}

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -183,6 +183,7 @@ func serve() func(cmd *cobra.Command, args []string) error {
 				cfg.Meter.Exporter,
 				cfg.Meter.Endpoint,
 				cfg.Meter.Insecure,
+				cfg.Meter.URLPath,
 			)
 			if err != nil {
 				slog.Error(err.Error())

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -141,6 +141,7 @@ func serve() func(cmd *cobra.Command, args []string) error {
 				cfg.Tracer.Exporter,
 				cfg.Tracer.Endpoint,
 				cfg.Tracer.Insecure,
+				cfg.Tracer.URLPath,
 			)
 			if err != nil {
 				slog.Error(err.Error())

--- a/pkg/telemetry/meterexporters/factory.go
+++ b/pkg/telemetry/meterexporters/factory.go
@@ -7,10 +7,10 @@ import (
 )
 
 // ExporterFactory - Create meter exporter according to given params
-func ExporterFactory(name, endpoint string) (metric.Exporter, error) {
+func ExporterFactory(name, endpoint string, insecure bool) (metric.Exporter, error) {
 	switch name {
 	case "otlp":
-		return NewOTLP(endpoint)
+		return NewOTLP(endpoint, insecure)
 	default:
 		return nil, fmt.Errorf("%s meter exporter is unsupported", name)
 	}

--- a/pkg/telemetry/meterexporters/factory.go
+++ b/pkg/telemetry/meterexporters/factory.go
@@ -7,10 +7,10 @@ import (
 )
 
 // ExporterFactory - Create meter exporter according to given params
-func ExporterFactory(name, endpoint string, insecure bool) (metric.Exporter, error) {
+func ExporterFactory(name, endpoint string, insecure bool, urlpath string) (metric.Exporter, error) {
 	switch name {
 	case "otlp":
-		return NewOTLP(endpoint, insecure)
+		return NewOTLP(endpoint, insecure, urlpath)
 	default:
 		return nil, fmt.Errorf("%s meter exporter is unsupported", name)
 	}

--- a/pkg/telemetry/meterexporters/otlp.go
+++ b/pkg/telemetry/meterexporters/otlp.go
@@ -8,10 +8,14 @@ import (
 )
 
 // NewOTLP - Creates new OTLP exporter
-func NewOTLP(endpoint string, insecure bool) (metric.Exporter, error) {
+func NewOTLP(endpoint string, insecure bool, urlpath string) (metric.Exporter, error) {
 	options := []otlpmetrichttp.Option{
 		otlpmetrichttp.WithCompression(otlpmetrichttp.GzipCompression),
 		otlpmetrichttp.WithEndpoint(endpoint),
+	}
+
+	if urlpath != "" {
+		options = append(options, otlpmetrichttp.WithURLPath(urlpath))
 	}
 
 	if insecure {

--- a/pkg/telemetry/meterexporters/otlp.go
+++ b/pkg/telemetry/meterexporters/otlp.go
@@ -8,13 +8,20 @@ import (
 )
 
 // NewOTLP - Creates new OTLP exporter
-func NewOTLP(endpoint string) (metric.Exporter, error) {
-	exporter, err := otlpmetrichttp.New(context.Background(),
+func NewOTLP(endpoint string, insecure bool) (metric.Exporter, error) {
+	options := []otlpmetrichttp.Option{
 		otlpmetrichttp.WithCompression(otlpmetrichttp.GzipCompression),
 		otlpmetrichttp.WithEndpoint(endpoint),
-	)
+	}
+
+	if insecure {
+		options = append(options, otlpmetrichttp.WithInsecure())
+	}
+
+	exporter, err := otlpmetrichttp.New(context.Background(), options...)
 	if err != nil {
 		return nil, err
 	}
+
 	return exporter, nil
 }

--- a/pkg/telemetry/tracerexporters/factory.go
+++ b/pkg/telemetry/tracerexporters/factory.go
@@ -7,14 +7,14 @@ import (
 )
 
 // ExporterFactory - Create tracer exporter according to given params
-func ExporterFactory(name, url string, insecure bool) (trace.SpanExporter, error) {
+func ExporterFactory(name, url string, insecure bool, urlpath string) (trace.SpanExporter, error) {
 	switch name {
 	case "zipkin":
 		return NewZipkin(url)
 	case "jaeger":
 		return NewJaegar(url)
 	case "otlp":
-		return NewOTLP(url, insecure)
+		return NewOTLP(url, insecure, urlpath)
 	case "signoz":
 		return NewSigNoz(url, insecure)
 	default:

--- a/pkg/telemetry/tracerexporters/otlp.go
+++ b/pkg/telemetry/tracerexporters/otlp.go
@@ -8,12 +8,16 @@ import (
 )
 
 // NewOTLP - Creates new OTLP exporter
-func NewOTLP(endpoint string, insecure bool) (trace.SpanExporter, error) {
+func NewOTLP(endpoint string, insecure bool, urlpath string) (trace.SpanExporter, error) {
 	var exporter trace.SpanExporter
 	var err error
 
 	opts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpoint(endpoint),
+	}
+
+	if urlpath != "" {
+		opts = append(opts, otlptracehttp.WithURLPath(urlpath))
 	}
 
 	if insecure {


### PR DESCRIPTION
Allow to configure insecure for meters and tracing
Allow to define URL path for OTLP tracing
https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp#WithURLPath