### PR TITLE
docs: add service config description for configuration

### DIFF
--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -75,7 +75,6 @@ service:
     cache:
       number_of_counters: 10_000
       max_cost: 10MiB
-  relationship:
 
 # The database section specifies the database engine and connection settings,
 # including the URI for the database, whether or not to auto-migrate the database,
@@ -419,6 +418,59 @@ audits, decision logs, authorization model)
 | database-garbage-collection-interval          | PERMIFY_DATABASE_GARBAGE_COLLECTION_INTERVAL           | duration |
 | database-garbage-collection-timeout           | PERMIFY_DATABASE_GARBAGE_COLLECTION_TIMEOUT            | duration |
 | database-garbage-collection-window            | PERMIFY_DATABASE_GARBAGE_COLLECTION_WINDOW             | duration |
+
+</p>
+</details>
+
+<details><summary>service | Service Configurations</summary>
+<p>
+
+#### Definition
+
+Configurations for the permify service and how it should behave. You can configure the circuit breaker pattern, configuration watcher, and service specific options for permission and schema services (rate limiting, concurrency limiting, cache size).
+
+#### Structure
+
+```
+├── service
+|   ├── circuit_breaker
+|   ├── watch:
+|   |   ├── enabled
+|   ├── schema:
+|   |   ├── cache:
+|   |   |   ├── number_of_counters
+|   |   |   ├── max_cost
+|   |   permission:
+|   |   |   ├── bulk_limit
+|   |   |   ├── concurrency_limit
+|   |   |   ├── cache:
+|   |   |   |   ├── number_of_counters
+|   |   |   |   ├── max_cost
+```
+
+#### Glossary
+
+| Required | Argument                            | Default | Description                                       |
+|----------|-------------------------------------|---------|---------------------------------------------------|
+| [ ]      | circuit_breaker                     | false   | switch option to use the circuit breaker pattern. |
+| [ ]      | watch                               | false   | switch option for configuration watcher.          |
+| [ ]      | schema.cache.number_of_counters     | 1_000   | number of counters for schema service.            |
+| [ ]      | schema.cache.max_cost               | 10MiB   | max cost for schema cache.                        |
+| [ ]      | permission.bulk_limit               | 100     | bulk operations limit for permission service.     |
+| [ ]      | permission.concurrency_limit        | 100     | concurrency limit for permission service.         |
+| [ ]      | permission.cache.max_cost           | 10MiB   | max cost for permission service.                  |
+
+#### ENV
+
+| Argument                                      | ENV                                                    | Type     |
+|-----------------------------------------------|--------------------------------------------------------|----------|
+| service-circuit-breaker                       | PERMIFY_SERVICE_CIRCUIT_BREAKER                        | boolean  |
+| service-watch-enabled                         | PERMIFY_SERVICE_WATCH_ENABLED                          | boolean  |
+| service-schema-cache-number-of-counters       | PERMIFY_SERVICE_SCHEMA_CACHE_NUMBER_OF_COUNTERS        | int      |
+| service-schema-cache-max-cost                 | PERMIFY_SERVICE_SCHEMA_CACHE_MAX_COST                  | int      |
+| service-permission-bulk-limit                 | PERMIFY_SERVICE_PERMISSION_BULK_LIMIT                  | int      |
+| service-permission-concurrency-limit          | PERMIFY_SERVICE_PERMISSION_CONCURRENCY_LIMIT           | int      |
+| service-permission-cache-max-cost             | PERMIFY_SERVICE_PERMISSION_CACHE_MAX_COST              | int      |
 
 </p>
 </details>

--- a/pkg/cmd/flags/serve.go
+++ b/pkg/cmd/flags/serve.go
@@ -310,6 +310,14 @@ func RegisterServeFlags(cmd *cobra.Command) {
 		panic(err)
 	}
 
+	flags.Int("service-permission-bulk-limit", conf.Service.Permission.BulkLimit, "bulk operations limit")
+	if err = viper.BindPFlag("service.permission.bulk_limit", flags.Lookup("service-permission-bulk-limit")); err != nil {
+		panic(err)
+	}
+	if err = viper.BindEnv("service.permission.bulk_limit", "PERMIFY_SERVICE_PERMISSION_BULK_LIMIT"); err != nil {
+		panic(err)
+	}
+
 	flags.Int("service-permission-concurrency-limit", conf.Service.Permission.ConcurrencyLimit, "concurrency limit")
 	if err = viper.BindPFlag("service.permission.concurrency_limit", flags.Lookup("service-permission-concurrency-limit")); err != nil {
 		panic(err)


### PR DESCRIPTION
This adds service config description for configuration as per #997 

I've done a parity check and made the following updates:
1. removed `service.relationship` this doesn't exist as an option
2. add flag and env binding for `service.permission.bulk_limit` as it is in the config & documentation but wasn't added as a flag