### PR TITLE
feat: error for unsupported psql versions

### DIFF
--- a/internal/factories/database.go
+++ b/internal/factories/database.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Permify/permify/internal/config"
 	"github.com/Permify/permify/internal/storage/memory/migrations"
+	"github.com/Permify/permify/internal/storage/postgres/utils"
 	"github.com/Permify/permify/pkg/database"
 	IMDatabase "github.com/Permify/permify/pkg/database/memory"
 	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
@@ -37,6 +38,12 @@ func DatabaseFactory(conf config.Database) (db database.Database, err error) {
 		if err != nil {
 			return nil, err
 		}
+		// check postgres version
+		_, err = utils.EnsureDBVersion(db.(*PQDatabase.Postgres).DB)
+		if err != nil {
+			return nil, err
+		}
+
 		return
 	case database.MEMORY.String():
 		db, err = IMDatabase.New(migrations.Schema)

--- a/internal/storage/migration.go
+++ b/internal/storage/migration.go
@@ -8,14 +8,16 @@ import (
 	"github.com/pressly/goose/v3"
 
 	"github.com/Permify/permify/internal/config"
+	"github.com/Permify/permify/internal/storage/postgres/utils"
 	"github.com/Permify/permify/pkg/database"
 	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 )
 
 const (
-	postgresMigrationDir = "postgres/migrations"
-	postgresDialect      = "postgres"
-	migrationsTable      = "migrations"
+	postgresMigrationDir    = "postgres/migrations"
+	postgresDialect         = "postgres"
+	migrationsTable         = "migrations"
+	earliestPostgresVersion = 130008
 )
 
 //go:embed postgres/migrations/*.sql
@@ -33,6 +35,12 @@ func Migrate(conf config.Database) (err error) {
 		}
 		// Ensure database connection is closed when function returns
 		defer closeDB(db)
+
+		// check postgres version
+		_, err = utils.EnsureDBVersion(db.DB)
+		if err != nil {
+			return err
+		}
 
 		// Set table name for migrations
 		goose.SetTableName(migrationsTable)

--- a/internal/storage/postgres/utils/version.go
+++ b/internal/storage/postgres/utils/version.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+const (
+	// The earliest supported version of PostgreSQL is 13.8
+	earliestPostgresVersion = 130008
+)
+
+// EnsureDBVersion checks the version of the given database connection and returns an error if the version is not
+// supported.
+func EnsureDBVersion(db *sql.DB) (version int, err error) {
+	err = db.QueryRow("SHOW server_version_num;").Scan(&version)
+	if err != nil {
+		return
+	}
+	if version < earliestPostgresVersion {
+		err = fmt.Errorf("unsupported postgres version: %d, expected >= %d", version, earliestPostgresVersion)
+	}
+	return
+}


### PR DESCRIPTION
/claim #1009

This adds a helper function that's used to verify postgres version. The helper function is then used in 2 places:
1. Migrations (this doesn't panic, but logs out an error that migrations couldn't be run)
2. DatabaseFactory (this will cause a panic and exit)