### PR TITLE
chore: add air support for hot reloading

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,33 @@
+# Config file for [Air](https://github.com/cosmtrek/air) in TOML format
+
+# Working directory
+# . or absolute path, please note that the directories following must be under root
+root = "."
+tmp_dir = "/tmp"
+
+[build]
+# Just plain old shell command. You could use `make` as well.
+cmd = "go build -o ./tmp/app/permify ./cmd/permify"
+# Binary file yields from `cmd`.
+bin = "/tmp/app"
+
+# Customize binary.
+# This is how you start to run your application. Since my application will works like CLI, so to run it, like to make a CLI call.
+full_bin = "./tmp/app/permify serve --database-engine postgres --database-uri postgres://postgres:secret@database:5432/permify --database-max-open-connections 20"
+# This log file places in your tmp_dir.
+log = "air_errors.log"
+# Watch these filename extensions.
+include_ext = ["go", "yaml",".env"]
+# Ignore these filename extensions or directories.
+exclude_dir = ["tmp", "docs"]
+# It's not necessary to trigger build each time file changes if it's too frequent.
+delay = 500 # ms
+
+[log]
+# Show log time
+time = true
+[color]
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 vendor/dist/
 /dist
 /config
+/tmp

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,10 @@
+FROM golang:1.21-alpine
+
+RUN apk --no-cache add curl
+# Install the air binary so we get live code-reloading when we save files
+RUN curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+
+# Run the air command in the directory where our code will live
+WORKDIR /app
+
+ENTRYPOINT [ "air" ]

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help: ## Display this help screen
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 compose-up: ### Run docker-compose
-	docker-compose up --build -d postgres && docker-compose logs -f
+	docker-compose up --build
 .PHONY: compose-up
 
 compose-up-integration-test: ### Run docker-compose with integration test

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,31 +1,40 @@
 version: "3.9"
 services:
-  permify:
-    image: "ghcr.io/permify/permify:latest"
-    command: "serve --database-engine postgres --database-uri postgres://postgres:secret@database:5432/permify --database-max-open-connections 20"
-    restart: "always"
-    ports:
-      - "3476:3476"
-      - "3478:3478"
-    depends_on:
-      - "database"
+    permify:
+        build:
+            context: .
+            dockerfile: Dockerfile.local
+        restart: "always"
+        ports:
+            - "3476:3476"
+            - "3478:3478"
+        volumes:
+            - .:/app
+        depends_on:
+            - "database"
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:3476/healthz"]
+            interval: 10s
+            retries: 10
+            start_period: 60s
 
-  database:
-    image: "postgres"
-    ports:
-      - "5432:5432"
-    environment:
-      - "POSTGRES_PASSWORD=secret"
-      - "POSTGRES_DB=permify"
+    database:
+        image: "postgres"
+        ports:
+            - "5432:5432"
+        environment:
+            - "POSTGRES_PASSWORD=secret"
+            - "POSTGRES_DB=permify"
 
-  integration:
-    build:
-      context: .
-      dockerfile: integration-test/Dockerfile
-    container_name: integration
-    image: integration
-    depends_on:
-      - permify
+    integration:
+        build:
+            context: .
+            dockerfile: integration-test/Dockerfile
+        container_name: integration
+        image: integration
+        depends_on:
+            permify:
+                condition: service_healthy
 
 volumes:
-  pg-data:
+    pg-data:


### PR DESCRIPTION
Updated docker configs and added an air config for faster development. Air watches all the go files and rebuilds whenever there is any change in the code to reflect in the API immediately resulting in rapid prototyping and experimenting.