### PR TITLE
fix: `slog` `!BADKEY` errors

### DIFF
--- a/internal/servers/server.go
+++ b/internal/servers/server.go
@@ -282,7 +282,7 @@ func (s *Container) Run(
 		}
 		defer func() {
 			if err = conn.Close(); err != nil {
-				slog.Error("Failed to close gRPC connection: %v", err)
+				slog.Error("Failed to close gRPC connection", "err", err)
 			}
 		}()
 

--- a/internal/servers/server.go
+++ b/internal/servers/server.go
@@ -220,7 +220,7 @@ func (s *Container) Run(
 			if err := pprofserver.ListenAndServe(); err != nil {
 				// Check if the error was due to the server being closed, and log it.
 				if errors.Is(err, http.ErrServerClosed) {
-					slog.Error("failed to start profiler", err)
+					slog.Error("failed to start profiler", slog.Any("error", err))
 				}
 			}
 		}()
@@ -241,13 +241,13 @@ func (s *Container) Run(
 	// Start the gRPC server.
 	go func() {
 		if err := grpcServer.Serve(lis); err != nil {
-			slog.Error("failed to start grpc server", err)
+			slog.Error("failed to start grpc server", slog.Any("error", err))
 		}
 	}()
 
 	go func() {
 		if err := invokeServer.Serve(invokeLis); err != nil {
-			slog.Error("failed to start invoke grpc server", err)
+			slog.Error("failed to start invoke grpc server", slog.Any("error", err))
 		}
 	}()
 
@@ -282,7 +282,7 @@ func (s *Container) Run(
 		}
 		defer func() {
 			if err = conn.Close(); err != nil {
-				slog.Error("Failed to close gRPC connection", "err", err)
+				slog.Error("Failed to close gRPC connection", slog.Any("error", err))
 			}
 		}()
 

--- a/internal/storage/postgres/gc/gc.go
+++ b/internal/storage/postgres/gc/gc.go
@@ -53,7 +53,7 @@ func (gc *GC) Start(ctx context.Context) error {
 		select {
 		case <-ticker.C: // Periodically trigger garbage collection.
 			if err := gc.Run(); err != nil {
-				slog.Error("Garbage collection failed:", err)
+				slog.Error("Garbage collection failed:", slog.Any("error", err))
 				continue
 			} else {
 				slog.Info("Garbage collection completed successfully")
@@ -73,7 +73,7 @@ func (gc *GC) Run() error {
 	var dbNow time.Time
 	err := gc.database.DB.QueryRowContext(ctx, "SELECT NOW() AT TIME ZONE 'UTC'").Scan(&dbNow)
 	if err != nil {
-		slog.Error("Failed to get current time from the database:", err)
+		slog.Error("Failed to get current time from the database:", slog.Any("error", err))
 		return err
 	}
 
@@ -83,7 +83,7 @@ func (gc *GC) Run() error {
 	// Retrieve the last transaction ID that occurred before the cutoff time.
 	lastTransactionID, err := gc.getLastTransactionID(ctx, cutoffTime)
 	if err != nil {
-		slog.Error("Failed to retrieve last transaction ID:", err)
+		slog.Error("Failed to retrieve last transaction ID:", slog.Any("error", err))
 		return err
 	}
 
@@ -93,15 +93,15 @@ func (gc *GC) Run() error {
 
 	// Delete records in relation_tuples, attributes, and transactions tables based on the lastTransactionID.
 	if err := gc.deleteRecords(ctx, postgres.RelationTuplesTable, lastTransactionID); err != nil {
-		slog.Error("Failed to delete records in relation_tuples:", err)
+		slog.Error("Failed to delete records in relation_tuples:", slog.Any("error", err))
 		return err
 	}
 	if err := gc.deleteRecords(ctx, postgres.AttributesTable, lastTransactionID); err != nil {
-		slog.Error("Failed to delete records in attributes:", err)
+		slog.Error("Failed to delete records in attributes:", slog.Any("error", err))
 		return err
 	}
 	if err := gc.deleteTransactions(ctx, lastTransactionID); err != nil {
-		slog.Error("Failed to delete transactions:", err)
+		slog.Error("Failed to delete transactions:", slog.Any("error", err))
 		return err
 	}
 

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -137,19 +137,19 @@ func serve() func(cmd *cobra.Command, args []string) error {
 		if cfg.Database.AutoMigrate {
 			err = storage.Migrate(cfg.Database)
 			if err != nil {
-				slog.Error("failed to migrate database", "err", err)
+				slog.Error("failed to migrate database", slog.Any("error", err))
 			}
 		}
 
 		// Initialize database
 		db, err := factories.DatabaseFactory(cfg.Database)
 		if err != nil {
-			slog.Error("failed to initialize database", "err", err)
+			slog.Error("failed to initialize database", slog.Any("error", err))
 			return err
 		}
 		defer func() {
 			if err = db.Close(); err != nil {
-				slog.Error("failed to close database", "err", err)
+				slog.Error("failed to close database", slog.Any("error", err))
 			}
 		}()
 

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -137,19 +137,19 @@ func serve() func(cmd *cobra.Command, args []string) error {
 		if cfg.Database.AutoMigrate {
 			err = storage.Migrate(cfg.Database)
 			if err != nil {
-				slog.Error("failed to migrate database: %w", err)
+				slog.Error("failed to migrate database", "err", err)
 			}
 		}
 
 		// Initialize database
 		db, err := factories.DatabaseFactory(cfg.Database)
 		if err != nil {
-			slog.Error("failed to initialize database: %w", err)
+			slog.Error("failed to initialize database", "err", err)
 			return err
 		}
 		defer func() {
 			if err = db.Close(); err != nil {
-				slog.Error("failed to close database: %v", err)
+				slog.Error("failed to close database", "err", err)
 			}
 		}()
 


### PR DESCRIPTION
`slog.Error` does not support string formatting, so I have removed `%w` and `%v` from `slog.Error` lines.
If no key is provided, it prints `!BADKEY` to the console. To avoid that, I put a key before the variables.