### PR TITLE
docs: fix configuration database env

### DIFF
--- a/docs/setting-up/configuration.mdx
+++ b/docs/setting-up/configuration.mdx
@@ -415,7 +415,7 @@ audits, decision logs, authorization model)
 | database-max-idle-connections        | PERMIFY_DATABASE_MAX_IDLE_CONNECTIONS        | int      |
 | database-max-connection-lifetime     | PERMIFY_DATABASE_MAX_CONNECTION_LIFETIME     | duration |
 | database-max-connection-idle-time    | PERMIFY_DATABASE_MAX_CONNECTION_IDLE_TIME    | duration |
-| database-garbage-collection-enabled  | PERMIFY_DATABASE_GARBAGE_ENABLED             | boolean  |
+| database-garbage-collection-enabled  | PERMIFY_DATABASE_GARBAGE_COLLECTION_ENABLED  | boolean  |
 | database-garbage-collection-interval | PERMIFY_DATABASE_GARBAGE_COLLECTION_INTERVAL | duration |
 | database-garbage-collection-timeout  | PERMIFY_DATABASE_GARBAGE_COLLECTION_TIMEOUT  | duration |
 | database-garbage-collection-window   | PERMIFY_DATABASE_GARBAGE_COLLECTION_WINDOW   | duration |


### PR DESCRIPTION
This tiny PR fixes environment variable typo.
Thank you.