### PR TITLE
docs: fix outdated grpc links

### DIFF
--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -12,7 +12,7 @@ We structured Permify API in 4 core parts:
 - [SchemaService]: Modeling and Permify Schema related functionalities including configuration and auditing.
 - [TenancyService]: Consists tenant operations such as creating, deleting and listing.
 
-Permify exposes its APIs via both [gRPC](https://buf.build/permify/permify/docs/main:base.v1) and [REST](https://restfulapi.net/).
+Permify exposes its APIs via both [gRPC](https://buf.build/permifyco/permify/docs/main:base.v1) and [REST](https://restfulapi.net/).
 
 [PermissionService]: ./permission/check-api
 [DataService]: ./data/write-data

--- a/docs/getting-started/enforcement.mdx
+++ b/docs/getting-started/enforcement.mdx
@@ -13,7 +13,7 @@ We structured Permify API in 4 core parts:
 - [SchemaService]: Modeling and Permify Schema related functionalities including configuration and auditing.
 - [TenancyService]: Consists tenant operations such as creating, deleting and listing.
 
-Permify exposes its APIs via both [gRPC](https://buf.build/permify/permify/docs/main:base.v1) and [REST](https://restfulapi.net/).
+Permify exposes its APIs via both [gRPC](https://buf.build/permifyco/permify/docs/main:base.v1) and [REST](https://restfulapi.net/).
 
 [PermissionService]: ./permission/check-api
 [DataService]: ./data/write-data


### PR DESCRIPTION
docs: fix outdated grpc links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the URLs for gRPC and REST APIs in the Permify documentation to reflect the new base URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->