### PR TITLE
docs: correct spelling error in configuration.mdx

### DIFF
--- a/docs/setting-up/configuration.mdx
+++ b/docs/setting-up/configuration.mdx
@@ -359,7 +359,7 @@ os, arch.
 
 | Required | Argument | Default | Description                                                  |
 |----------|----------|---------|--------------------------------------------------------------|
-| [x]      | exporter | -       | [otpl](https://opentelemetry.io/docs/collector/) is default. |
+| [x]      | exporter | -       | [otlp](https://opentelemetry.io/docs/collector/) is default. |
 | [x]      | endpoint | -       | export uri for metric observation                            |
 | [ ]      | enabled  | true    | switch option for meter tracing.                             |
 


### PR DESCRIPTION
 ### Description

This pull request fixes a spelling mistake in `docs/setting-up/configuration.mdx`. The term 'otpl' was corrected to 'otlp'.

### Related Issue

Closes  #1392 
