### PR TITLE
chore(dependabot): remove open pull request limits for gomod and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 15
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "monthly"  
-    open-pull-requests-limit: 15
   - package-ecosystem: "npm"
     directory: "/playground"
     schedule:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated configuration to allow for an unlimited number of open pull requests for Docker and npm package ecosystems.
  
- **Impact**
	- This change may streamline the dependency update process but requires careful monitoring to manage potential overwhelming updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->