### PR TITLE
docs: update the roadmap link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Before start please see our [contributing guide](https://github.com/Permify/perm
 
 ## Roadmap
 
-You can find Permify's Public Roadmap [here](https://permify.featurebase.app/roadmap)!
+You can find Permify's Public Roadmap [here](https://github.com/orgs/Permify/projects/1)!
 
 ## Contributors ♥️
 


### PR DESCRIPTION
docs: update the roadmap link in readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the link to Permify's Public Roadmap in the README, now directing users to a GitHub project page for improved access to project management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->