### PR TITLE
fix: plan_cache_mode issue for RDS Proxy

### DIFF
--- a/pkg/database/postgres/postgres.go
+++ b/pkg/database/postgres/postgres.go
@@ -180,15 +180,21 @@ func setDefaultQueryExecMode(config *pgx.ConnConfig) {
 var planCacheModes = map[string]string{
 	"auto":              "auto",
 	"force_custom_plan": "force_custom_plan",
+	"disable":		"disable",
 }
 
 func setPlanCacheMode(config *pgx.ConnConfig) {
 	// Default mode if no specific mode is found in the connection string
 	defaultMode := "auto"
-
+	
 	// Check if a plan cache mode is mentioned in the connection string and set it
 	for key := range planCacheModes {
 		if strings.Contains(config.ConnString(), "plan_cache_mode="+key) {
+            if key == "disable" {
+				delete(config.Config.RuntimeParams, "plan_cache_mode")
+                slog.Info("plan_cache_mode disabled")
+                return
+            }
 			config.Config.RuntimeParams["plan_cache_mode"] = planCacheModes[key]
 			slog.Info("setPlanCacheMode", slog.String("mode", key))
 			return


### PR DESCRIPTION
fix: [BUG] Permify on AWS EKS using an RDS PostgreSQL #1340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new option to disable the plan cache mode in PostgreSQL connection configurations, providing users with enhanced control over performance settings.

- **Bug Fixes**
	- Improved handling of connection string parameters related to plan cache mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->