### PR TITLE
fix: fixed pagination typos

### DIFF
--- a/docs/api-reference/apidocs.swagger.json
+++ b/docs/api-reference/apidocs.swagger.json
@@ -2280,7 +2280,7 @@
         "page_size": {
           "type": "integer",
           "format": "int64",
-          "description": "page_size is the number of tenants to be returned in the response.\nThe value should be between 1 and 100."
+          "description": "page_size is the number of entities to be returned in the response.\nThe value should be between 1 and 100."
         },
         "continuous_token": {
           "type": "string",
@@ -2322,7 +2322,7 @@
         "page_size": {
           "type": "integer",
           "format": "int64",
-          "description": "page_size is the number of tenants to be returned in the response.\nThe value should be between 1 and 100."
+          "description": "page_size is the number of entities to be returned in the response.\nThe value should be between 1 and 100."
         },
         "continuous_token": {
           "type": "string",
@@ -2357,7 +2357,7 @@
         "page_size": {
           "type": "integer",
           "format": "int64",
-          "description": "page_size is the number of tenants to be returned in the response.\nThe value should be between 1 and 100."
+          "description": "page_size is the number of subjects to be returned in the response.\nThe value should be between 1 and 100."
         },
         "continuous_token": {
           "type": "string",
@@ -2920,7 +2920,7 @@
         "page_size": {
           "type": "integer",
           "format": "int64",
-          "description": "page_size is the number of tenants to be returned in the response.\nThe value should be between 1 and 100."
+          "description": "page_size is the number of schemas to be returned in the response.\nThe value should be between 1 and 100."
         },
         "continuous_token": {
           "type": "string",

--- a/docs/api-reference/openapiv2/apidocs.swagger.json
+++ b/docs/api-reference/openapiv2/apidocs.swagger.json
@@ -2270,7 +2270,7 @@
         "page_size": {
           "type": "integer",
           "format": "int64",
-          "description": "page_size is the number of tenants to be returned in the response.\nThe value should be between 1 and 100."
+          "description": "page_size is the number of entities to be returned in the response.\nThe value should be between 1 and 100."
         },
         "continuous_token": {
           "type": "string",
@@ -2312,7 +2312,7 @@
         "page_size": {
           "type": "integer",
           "format": "int64",
-          "description": "page_size is the number of tenants to be returned in the response.\nThe value should be between 1 and 100."
+          "description": "page_size is the number of entities to be returned in the response.\nThe value should be between 1 and 100."
         },
         "continuous_token": {
           "type": "string",
@@ -2347,7 +2347,7 @@
         "page_size": {
           "type": "integer",
           "format": "int64",
-          "description": "page_size is the number of tenants to be returned in the response.\nThe value should be between 1 and 100."
+          "description": "page_size is the number of subjects to be returned in the response.\nThe value should be between 1 and 100."
         },
         "continuous_token": {
           "type": "string",
@@ -2902,7 +2902,7 @@
         "page_size": {
           "type": "integer",
           "format": "int64",
-          "description": "page_size is the number of tenants to be returned in the response.\nThe value should be between 1 and 100."
+          "description": "page_size is the number of schemas to be returned in the response.\nThe value should be between 1 and 100."
         },
         "continuous_token": {
           "type": "string",

--- a/pkg/pb/base/v1/service.pb.go
+++ b/pkg/pb/base/v1/service.pb.go
@@ -607,7 +607,7 @@ type PermissionLookupEntityRequest struct {
 	// Scope: A map that associates entity types with lists of identifiers. Each entry
 	// helps filter requests by specifying which entities are relevant to the operation.
 	Scope map[string]*StringArrayValue `protobuf:"bytes,7,rep,name=scope,proto3" json:"scope,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	// page_size is the number of tenants to be returned in the response.
+	// page_size is the number of entities to be returned in the response.
 	// The value should be between 1 and 100.
 	PageSize uint32 `protobuf:"varint,8,opt,name=page_size,proto3" json:"page_size,omitempty"`
 	// continuous_token is an optional parameter used for pagination.
@@ -1083,7 +1083,7 @@ type PermissionLookupSubjectRequest struct {
 	SubjectReference *RelationReference `protobuf:"bytes,5,opt,name=subject_reference,proto3" json:"subject_reference,omitempty"`
 	// Context associated with this request.
 	Context *Context `protobuf:"bytes,6,opt,name=context,proto3" json:"context,omitempty"`
-	// page_size is the number of tenants to be returned in the response.
+	// page_size is the number of subjects to be returned in the response.
 	// The value should be between 1 and 100.
 	PageSize uint32 `protobuf:"varint,7,opt,name=page_size,proto3" json:"page_size,omitempty"`
 	// continuous_token is an optional parameter used for pagination.
@@ -2072,7 +2072,7 @@ type SchemaListRequest struct {
 	// tenant_id is a string that identifies the tenant. It must match the pattern "[a-zA-Z0-9-,]+",
 	// be a maximum of 64 bytes, and must not be empty.
 	TenantId string `protobuf:"bytes,1,opt,name=tenant_id,proto3" json:"tenant_id,omitempty"`
-	// page_size is the number of tenants to be returned in the response.
+	// page_size is the number of schemas to be returned in the response.
 	// The value should be between 1 and 100.
 	PageSize uint32 `protobuf:"varint,2,opt,name=page_size,proto3" json:"page_size,omitempty"`
 	// continuous_token is an optional parameter used for pagination.

--- a/proto/base/v1/service.proto
+++ b/proto/base/v1/service.proto
@@ -1045,7 +1045,7 @@ message PermissionLookupEntityRequest {
   // helps filter requests by specifying which entities are relevant to the operation.
   map<string, StringArrayValue> scope = 7 [json_name = "scope"];
 
-  // page_size is the number of tenants to be returned in the response.
+  // page_size is the number of entities to be returned in the response.
   // The value should be between 1 and 100.
   uint32 page_size = 8 [
     json_name = "page_size",
@@ -1208,7 +1208,7 @@ message PermissionLookupSubjectRequest {
   // Context associated with this request.
   Context context = 6 [json_name = "context"];
 
-  // page_size is the number of tenants to be returned in the response.
+  // page_size is the number of subjects to be returned in the response.
   // The value should be between 1 and 100.
   uint32 page_size = 7 [
     json_name = "page_size",
@@ -1898,7 +1898,7 @@ message SchemaListRequest {
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Identifier of the tenant, if you are not using multi-tenancy (have only one tenant) use pre-inserted tenant <code>t1</code> for this field. Required, and must match the pattern \\“[a-zA-Z0-9-,]+\\“, max 64 bytes."}
   ];
 
-  // page_size is the number of tenants to be returned in the response.
+  // page_size is the number of schemas to be returned in the response.
   // The value should be between 1 and 100.
   uint32 page_size = 2 [
     json_name = "page_size",


### PR DESCRIPTION
- we had typos at pagination parameter comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated API documentation to clarify that the `page_size` parameter refers to the number of entities, subjects, or schemas, rather than just tenants.
	- Enhanced descriptions across multiple sections to improve clarity and accuracy for end-users.
	- Maintained the value range for `page_size` between 1 and 100.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->