### PR TITLE
docs(oidc): add description for backoff_frequency argument

### DIFF
--- a/docs/setting-up/configuration.mdx
+++ b/docs/setting-up/configuration.mdx
@@ -264,6 +264,7 @@ authentication.
 |       ├── audience
 |       ├── refresh_interval
 |       ├── backoff_interval
+|       ├── backoff_frequency
 |       ├── backoff_max_retries
 |       ├── valid_methods
 ```
@@ -278,21 +279,23 @@ authentication.
 | [x]      | issuer              | -                 | This is the URL of the provider that is responsible for authenticating users. You will use this URL to discover information about the provider in step 1 of the authentication process.   |
 | [x]      | refresh_interval    | 15m               | The interval at which the authentication information should be refreshed to ensure that it remains valid and up-to-date.                                                                  |
 | [x]      | backoff_interval    | 12s               | The delay between retries when attempting to authenticate if the key is not found. The system will retry at intervals, which may vary, to avoid constant retry attempts.                  |
+| [x]      | backoff_frequency   | -                 | The duration to wait before retrying after a failed authentication attempt. This helps to manage the load on the authentication service by introducing a delay between retries, ensuring that repeated failures do not overwhelm the service or lead to excessive requests. This value should be configured according to the expected response times and reliability of the authentication provider.                  |
 | [x]      | backoff_max_retries | 5                 | The maximum number of retry attempts to make if key is not found.                                                                                                                         |
 | [x]      | valid_methods       | ["RS256","HS256"] | A list of accepted signing methods for tokens. This ensures that only tokens signed using one of the specified algorithms will be considered valid.                                        |
 
 #### ENV
 
-| Argument                       | ENV                                 | Type          |
-|--------------------------------|-------------------------------------|---------------|
-| authn-enabled                  | PERMIFY_AUTHN_ENABLED               | boolean       |
-| authn-method                   | PERMIFY_AUTHN_METHOD                | string        |
-| authn-oidc-issuer              | PERMIFY_AUTHN_OIDC_ISSUER           | string        |
-| authn-oidc-audience            | PERMIFY_AUTHN_OIDC_AUDIENCE         | string        |
-| authn-oidc-refresh-interval    | PERMIFY_AUTHN_OIDC_REFRESH_INTERVAL | duration      |
-| authn-oidc-backoff-interval    | PERMIFY_AUTHN_OIDC_BACKOFF_INTERVAL | duration      |
-| authn-oidc-backoff-max-retries | PERMIFY_AUTHN_OIDC_BACKOFF_RETRIES  | int           |
-| authn-oidc-valid-methods       | PERMIFY_AUTHN_OIDC_VALID_METHODS    | string array  |
+| Argument                        | ENV                                  | Type          |
+|---------------------------------|--------------------------------------|---------------|
+| authn-enabled                   | PERMIFY_AUTHN_ENABLED                | boolean       |
+| authn-method                    | PERMIFY_AUTHN_METHOD                 | string        |
+| authn-oidc-issuer               | PERMIFY_AUTHN_OIDC_ISSUER            | string        |
+| authn-oidc-audience             | PERMIFY_AUTHN_OIDC_AUDIENCE          | string        |
+| authn-oidc-refresh-interval     | PERMIFY_AUTHN_OIDC_REFRESH_INTERVAL  | duration      |
+| authn-oidc-backoff-interval     | PERMIFY_AUTHN_OIDC_BACKOFF_INTERVAL  | duration      |
+| authn-oidc-backoff-frequency    | PERMIFY_AUTHN_OIDC_BACKOFF_FREQUENCY | duration      |
+| authn-oidc-backoff-max-retries  | PERMIFY_AUTHN_OIDC_BACKOFF_RETRIES   | int           |
+| authn-oidc-valid-methods        | PERMIFY_AUTHN_OIDC_VALID_METHODS     | string array  |
 
 </Accordion>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration parameter, `backoff_frequency`, for managing retry intervals after failed authentication attempts.
	- Added a new environment variable, `authn-oidc-backoff-frequency`, to facilitate configuration through environment settings.

- **Documentation**
	- Updated documentation to include details about the new `backoff_frequency` parameter and its configuration considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->