### PR TITLE
refactor: update Ristretto cache type to use generics

### DIFF
--- a/pkg/cache/interfaces.go
+++ b/pkg/cache/interfaces.go
@@ -2,8 +2,8 @@ package cache
 
 // Cache - Defines an interface for a generic cache.
 type Cache interface {
-	Get(key interface{}) (interface{}, bool)
-	Set(key, value interface{}, cost int64) bool
+	Get(key string) (any, bool)
+	Set(key string, value any, cost int64) bool
 	Wait()
 	Close()
 }
@@ -13,11 +13,11 @@ type noopCache struct{}
 
 func NewNoopCache() Cache { return &noopCache{} }
 
-func (c *noopCache) Get(_ any) (any, bool) {
+func (c *noopCache) Get(_ string) (any, bool) {
 	return nil, false
 }
 
-func (c *noopCache) Set(_, _ any, _ int64) bool {
+func (c *noopCache) Set(_ string, _ any, _ int64) bool {
 	return false
 }
 

--- a/pkg/cache/ristretto/ristretto.go
+++ b/pkg/cache/ristretto/ristretto.go
@@ -11,7 +11,7 @@ type Ristretto struct {
 	maxCost     string
 	bufferItems int64
 
-	c *ristretto.Cache
+	c *ristretto.Cache[string, any]
 }
 
 // New - Creates new ristretto cache
@@ -32,7 +32,7 @@ func New(opts ...Option) (*Ristretto, error) {
 		return nil, err
 	}
 
-	c, err := ristretto.NewCache(&ristretto.Config{
+	c, err := ristretto.NewCache(&ristretto.Config[string, any]{
 		NumCounters: rs.numCounters,
 		MaxCost:     int64(mc),
 		BufferItems: rs.bufferItems,
@@ -44,12 +44,12 @@ func New(opts ...Option) (*Ristretto, error) {
 }
 
 // Get - Gets value from cache
-func (r *Ristretto) Get(key interface{}) (interface{}, bool) {
+func (r *Ristretto) Get(key string) (interface{}, bool) {
 	return r.c.Get(key)
 }
 
 // Set - Sets value to cache
-func (r *Ristretto) Set(key, value interface{}, cost int64) bool {
+func (r *Ristretto) Set(key string, value any, cost int64) bool {
 	return r.c.Set(key, value, cost)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated cache interface to enforce string keys, enhancing type safety and clarity.
	- Introduced type parameterization in the Ristretto cache for improved type handling.

- **Bug Fixes**
	- Ensured consistency in method signatures across cache implementations for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->