### PR TITLE
fix: fix the argument of slog.Error

### DIFF
--- a/pkg/telemetry/meter.go
+++ b/pkg/telemetry/meter.go
@@ -73,7 +73,7 @@ func NewCounter(meter omt.Meter, name, description string) omt.Int64Counter {
 		omt.WithDescription(description),
 	)
 	if err != nil {
-		slog.Error("failed to create counter: ", err)
+		slog.Error("failed to create counter", slog.String("error", err.Error()))
 		panic(err)
 	}
 
@@ -87,7 +87,7 @@ func NewHistogram(meter omt.Meter, name, unit, description string) omt.Int64Hist
 		omt.WithDescription(description),
 	)
 	if err != nil {
-		slog.Error("failed to create histogram: ", err)
+		slog.Error("failed to create histogram: ", slog.String("error", err.Error()))
 		panic(err)
 	}
 


### PR DESCRIPTION
slog.Error arg "err" should be a string or a slog.Attr 
https://pkg.go.dev/log/slog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error logging format for better clarity in error messages related to counter and histogram creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->