### PR TITLE
docs: move partial schema update to api-reference

### DIFF
--- a/docs/api-reference/health/health-api.mdx
+++ b/docs/api-reference/health/health-api.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /healthz
+---

--- a/docs/api-reference/schema/partial-write.mdx
+++ b/docs/api-reference/schema/partial-write.mdx
@@ -1,13 +1,12 @@
 ---
-icon: pen
-title: Partial Schema Update 
+title: Partial Schema Update
+openapi: patch /v1/tenants/{tenant_id}/schemas/partial-write
 ---
+
 
 As development teams regularly roll out new features or API endpoints, features each addition often necessitates corresponding updates to the Permify schema. 
 
 To streamline this process, we have published an endpoint allows authorized users to make partial updates to the schema by adding or modifying actions within individual entities.
-
-gRPC: https://buf.build/permifyco/permify/docs/main:base.v1#base.v1.Schema.PartialWrite
 
 ## **Endpoint Definition**
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -320,8 +320,7 @@
         "operations/cache",
         "operations/contextual-tuples",
         "operations/tracing",
-        "operations/snap-tokens",
-        "operations/partial-schema-update"
+        "operations/snap-tokens"
       ]
     },
     {
@@ -367,6 +366,7 @@
       "pages": [
         "api-reference/schema/write-schema",
         "api-reference/schema/list-schema",
+        "api-reference/schema/partial-write",
         "api-reference/schema/read-schema"
       ]
     },


### PR DESCRIPTION
docs: move partial schema update to api-reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced OpenAPI specifications for the health check and partial schema update endpoints.
	- Enhanced API documentation with new references for partial write functionality.

- **Bug Fixes**
	- Clarified documentation regarding partial updates to schemas.

- **Documentation**
	- Updated `docs/mint.json` to reflect changes in operations and added new API reference pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->