### PR TITLE
docs: change command in quickstart

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -30,7 +30,7 @@ Production usage of Permify needs some configurations such as defining running o
 However, for the sake of this tutorial we'll not do any configurations and quickly start Permify on your local with running the docker command below:
 
 ```shell
-docker run -p 3476:3476 -p 3478:3478  ghcr.io/permify/permify
+docker run -p 3476:3476 -p 3478:3478  ghcr.io/permify/permify serve 
 ```
 
 This will start Permify with the default configuration options: 


### PR DESCRIPTION
docs: change command in quickstart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and accuracy in the setup instructions for the Permify service.
	- Specified minimum requirements, including PostgreSQL version 13.8 or higher.
	- Updated Docker command for running the Permify service to clarify usage.
	- Enhanced descriptions and examples in various sections for better understanding.
	- Emphasized the necessity of the `tenant_id` parameter in API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->