### PR TITLE
build: expose openapi on http server

### DIFF
--- a/example.config.yaml
+++ b/example.config.yaml
@@ -8,6 +8,7 @@ server:
   http:
     enabled: true
     port: 3476
+    expose_openapi: false
     tls:
       enabled: false
       cert: /etc/letsencrypt/live/yourdomain.com/fullchain.pem

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ type (
 	HTTP struct {
 		Enabled            bool      `mapstructure:"enabled"`              // Whether the HTTP server is enabled
 		Port               string    `mapstructure:"port"`                 // Port for the HTTP server
+		ExposeOpenAPI			 bool 		 `mapstructure:"expose_openapi"` // expose OpenAPI configuration
 		TLSConfig          TLSConfig `mapstructure:"tls"`                  // TLS configuration for the HTTP server
 		CORSAllowedOrigins []string  `mapstructure:"cors_allowed_origins"` // List of allowed origins for CORS
 		CORSAllowedHeaders []string  `mapstructure:"cors_allowed_headers"` // List of allowed headers for CORS
@@ -276,6 +277,7 @@ func DefaultConfig() *Config {
 			HTTP: HTTP{
 				Enabled: true,
 				Port:    "3476",
+				ExposeOpenAPI: false,
 				TLSConfig: TLSConfig{
 					Enabled: false,
 				},


### PR DESCRIPTION
Adding an http endpoint to expose the openapi.json file
[http://hostname:port/openapi.json](http://hostname:port/openapi.json)

Also allow to enable the exposition or not using the config, not exposed by default to keep the actual behavior.

If you need to expose your openAPI, you can add the following configuration:

```yaml
server:
  http:
    enabled: true
    expose_openapi: false
```

close #1714