### PR TITLE
fix: log name is updated as identifier instead of permify

### DIFF
--- a/pkg/cmd/log.go
+++ b/pkg/cmd/log.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Permify/sloggcp"
 	"github.com/agoda-com/opentelemetry-go/otelslog"
 
+	"github.com/Permify/permify/internal"
 	"github.com/Permify/permify/pkg/telemetry"
 	"github.com/Permify/permify/pkg/telemetry/logexporters"
 )
@@ -60,7 +61,7 @@ func NewGCPHandler(headers map[string]string, level slog.Leveler) (slog.Handler,
 	}
 
 	// Initialize GCP-specific log handler
-	logName := "permify"
+	logName := internal.Identifier
 	gcpHandler := sloggcp.NewGoogleCloudSlogHandler(context.Background(), projectId, logName, &slog.HandlerOptions{
 		Level: level,
 	})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the log name configuration for the Google Cloud logging handler to enhance flexibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->