### PR TITLE
docs: hide end-to-end example highlight oss quickstart

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -242,7 +242,7 @@
     {
       "group": "Getting Started",
       "pages": [
-        "getting-started/end-to-end-example",
+        "getting-started/quickstart",
         "getting-started/modeling",
         "getting-started/sync-data",
         "getting-started/enforcement",


### PR DESCRIPTION
docs: hide end-to-end example highlight oss quickstart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated navigation structure to prioritize the "Quickstart" guide over the "End-to-End Example."
  
- **Chores**
	- Expanded redirection rules for improved user navigation across documentation versions and sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->