### PR TITLE
docs: fix permission check example

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -195,7 +195,7 @@ Lets get back to our example and perform an example access check via [Check API]
 [Check API]: ../../../api-reference/permission/check-api
 [Permify Schema]: ../getting-started/modeling
 
-***Can the user 45 view files on organization 1 ?***
+***Can the user 1 view files on organization 1 ?***
 
 **POST** `/v1/tenants/{tenant_id}/permissions/check`
 
@@ -224,7 +224,7 @@ Lets get back to our example and perform an example access check via [Check API]
   "permission": "view_files",
   "subject": {
     "type": "user",
-    "id": "45",
+    "id": "1",
     "relation": ""
   },
 }


### PR DESCRIPTION
In the quickstart docs we [create an authorized admin user with id:1 ](https://github.com/Permify/permify/blob/master/docs/getting-started/quickstart.mdx?plain=1#L167) and then do a [permissions check against user:45](https://github.com/Permify/permify/blob/master/docs/getting-started/quickstart.mdx?plain=1#L227), expecting an [allowed result](https://github.com/Permify/permify/blob/master/docs/getting-started/quickstart.mdx?plain=1#L237)

We should either expect user 45 to be denied, or perform the check against user id 1 to get an allowed result



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the quickstart guide for clearer setup and usage of the Permify service.
	- Specified PostgreSQL version requirements and streamlined Docker setup instructions.
	- Enhanced health check instructions with an HTTP GET request example.
	- Expanded guidance on modeling authorization and adjusted examples for clarity.
	- Added warnings about schema conversion and updated API configuration details for multi-tenancy.
	- Improved examples for granting roles and corrected user ID in access check section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->