### PR TITLE
refactor: replace usages of `golang.org/x/exp` with stdlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.32.0
 	go.opentelemetry.io/otel/sdk/metric v1.32.0
 	go.opentelemetry.io/otel/trace v1.32.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/net v0.31.0
 	golang.org/x/sync v0.9.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20241118233622-e639e219e697
@@ -104,6 +103,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.24.10 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/time v0.7.0 // indirect
 	google.golang.org/api v0.203.0 // indirect

--- a/internal/engines/subjectFilter.go
+++ b/internal/engines/subjectFilter.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
 	"github.com/google/cel-go/cel"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/Permify/permify/internal/schema"
 	"github.com/Permify/permify/internal/storage"

--- a/internal/engines/subjectPermission.go
+++ b/internal/engines/subjectPermission.go
@@ -3,9 +3,8 @@ package engines
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/Permify/permify/internal/invoke"
 	"github.com/Permify/permify/internal/storage"

--- a/internal/storage/context/attributes.go
+++ b/internal/storage/context/attributes.go
@@ -1,9 +1,8 @@
 package context
 
 import (
+	"slices"
 	"sort"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/Permify/permify/internal/storage/context/utils"
 	"github.com/Permify/permify/pkg/database"

--- a/internal/storage/context/tuples.go
+++ b/internal/storage/context/tuples.go
@@ -1,9 +1,8 @@
 package context
 
 import (
+	"slices"
 	"sort"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/Permify/permify/internal/storage/context/utils"
 	"github.com/Permify/permify/pkg/database"

--- a/internal/storage/context/tuples_test.go
+++ b/internal/storage/context/tuples_test.go
@@ -1,9 +1,8 @@
 package context
 
 import (
+	"slices"
 	"testing"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/Permify/permify/pkg/database"
 	base "github.com/Permify/permify/pkg/pb/base/v1"

--- a/internal/storage/memory/dataReader.go
+++ b/internal/storage/memory/dataReader.go
@@ -3,11 +3,10 @@ package memory
 import (
 	"context"
 	"errors"
+	"slices"
 	"sort"
 	"strconv"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/hashicorp/go-memdb"
 

--- a/internal/storage/memory/utils/filter.go
+++ b/internal/storage/memory/utils/filter.go
@@ -1,8 +1,9 @@
 package utils
 
 import (
+	"slices"
+
 	"github.com/hashicorp/go-memdb"
-	"golang.org/x/exp/slices"
 
 	"github.com/Permify/permify/internal/storage"
 	base "github.com/Permify/permify/pkg/pb/base/v1"

--- a/internal/storage/postgres/utils/common.go
+++ b/internal/storage/postgres/utils/common.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"math/rand/v2"
 	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/codes"
-	"golang.org/x/exp/rand"
 
 	"go.opentelemetry.io/otel/trace"
 

--- a/pkg/database/postgres/postgres.go
+++ b/pkg/database/postgres/postgres.go
@@ -3,14 +3,13 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 
 	"github.com/exaring/otelpgx"
-
-	"golang.org/x/exp/slog"
 
 	"github.com/jackc/pgx/v5"
 

--- a/pkg/development/coverage/coverage.go
+++ b/pkg/development/coverage/coverage.go
@@ -2,8 +2,7 @@ package coverage
 
 import (
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/Permify/permify/pkg/attribute"
 	"github.com/Permify/permify/pkg/development/file"

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -3,9 +3,8 @@ package tuple
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	base "github.com/Permify/permify/pkg/pb/base/v1"
 )


### PR DESCRIPTION
These experimental packages are available in the Go standard library already. We have upgraded our Go version to 1.23 in https://github.com/Permify/permify/pull/1483 so we can replace them with the standard library.

- `golang.org/x/exp/rand`: Available in Go 1.22 [^2]
- `golang.org/x/exp/slices`: Available in Go 1.21 [^3]
- `golang.org/x/exp/slog`: Available in Go 1.21 [^1]

[^1]: https://go.dev/doc/go1.21#slog
[^2]: https://go.dev/doc/go1.22#math_rand_v2
[^3]: https://go.dev/doc/go1.21#slices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced permission filtering logic for improved clarity and robustness.
  
- **Bug Fixes**
	- Improved error handling and response management in permission checks.
  
- **Refactor**
	- Updated import statements to utilize the standard library's `slices` package across multiple files, enhancing maintainability.
	- Streamlined logging for PostgreSQL connection pool configuration.

- **Chores**
	- Cleaned up dependency management by reinstating the `golang.org/x/exp` module as indirect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->