### PR TITLE
chore(docs): added links to Otel tools in Otel exporter doc

### DIFF
--- a/docs/integrations/metrics/otlp.mdx
+++ b/docs/integrations/metrics/otlp.mdx
@@ -44,7 +44,7 @@ Ensure that your configuration file is loaded when starting Permify, and confirm
 
 ### Step 4: View Traces in Your Chosen UI
 
-Once the setup is complete and your application begins sending traces, you can view the trace data in a backend such as Jaeger, Zipkin, or any system supported by the OpenTelemetry Collector.
+Once the setup is complete and your application begins sending traces, you can view the trace data in a backend such as [Jaeger](https://www.jaegertracing.io), [Zipkin](https://zipkin.io), [Dash0](https://www.dash0.com) or any system supported by the OpenTelemetry Collector.
 
 ### Meter Configuration
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated OpenTelemetry setup documentation with additional details and external resource links for Jaeger, Zipkin, and Dash0.
	- Modified example configuration for exporting metrics to specify a network-oriented endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->