### PR TITLE
fix: checkDepth should throw error if depth <= 0

### DIFF
--- a/internal/invoke/utils.go
+++ b/internal/invoke/utils.go
@@ -9,7 +9,7 @@ import (
 
 // checkDepth - a helper function that returns an error if the depth in a PermissionCheckRequest is zero.
 func checkDepth(request *base.PermissionCheckRequest) error {
-	if atomic.LoadInt32(&request.GetMetadata().Depth) == 0 {
+	if atomic.LoadInt32(&request.GetMetadata().Depth) <= 0 {
 		return errors.New(base.ErrorCode_ERROR_CODE_DEPTH_NOT_ENOUGH.String())
 	}
 	return nil

--- a/internal/invoke/utils.go
+++ b/internal/invoke/utils.go
@@ -7,7 +7,7 @@ import (
 	base "github.com/Permify/permify/pkg/pb/base/v1"
 )
 
-// checkDepth - a helper function that returns an error if the depth in a PermissionCheckRequest is zero.
+// checkDepth - a helper function that returns an error if the depth in a PermissionCheckRequest is <= zero.
 func checkDepth(request *base.PermissionCheckRequest) error {
 	if atomic.LoadInt32(&request.GetMetadata().Depth) <= 0 {
 		return errors.New(base.ErrorCode_ERROR_CODE_DEPTH_NOT_ENOUGH.String())


### PR DESCRIPTION
This can be reproduced by making a complex request with a large depth. From my understanding, as the check trees grows the many simultaneous goroutines can decrement depth below 0 before the next `checkDepth`, making this method run for unbounded time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated depth validation logic to handle zero and negative depth values more comprehensively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->