### PR TITLE
feat(ci): update goreleaser version to use v2 range for nightly releases

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: ~> v2
           args: release -f nightly.goreleaser.yml --clean --nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the nightly release process to ensure it uses the latest compatible release within the major version 2 series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->