### PR TITLE
feat: add OTEL handler for http server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.35.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0
 	go.opentelemetry.io/contrib/instrumentation/host v0.59.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.59.0
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0
@@ -100,7 +101,6 @@ require (
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.24.12 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0 // indirect
 	golang.org/x/oauth2 v0.26.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/api v0.216.0 // indirect


### PR DESCRIPTION
At the moment, OTEL traces are not joined up between our HTTP requests and Permify. This PR aims to rectify that.

Adding the `otelhttp` wiring will mean:
- HTTP requests will be traced.
- Trace propagation from HTTP clients all the way through to gRPC, database, etc will work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced monitoring and observability improvements have been introduced for HTTP request processing. This update leverages modern telemetry integration to bolster system diagnostics and performance tracking. As a result, the platform now delivers a more stable and responsive experience under varying load conditions, helping ensure smoother operations for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->