### PR TITLE
feat: improve HTTP server span formatting further

### DIFF
--- a/pkg/telemetry/tracer.go
+++ b/pkg/telemetry/tracer.go
@@ -7,6 +7,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
@@ -35,5 +36,7 @@ func NewTracer(exporter trace.SpanExporter) func(context.Context) error {
 		)),
 	)
 	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
 	return tp.Shutdown
 }


### PR DESCRIPTION
- The previous method produced high cardinality span names.
- This approach improves the naming to read the path from the mux.
- Sorry for the iterating on this - I wasn't expecting the last PR to get merged so soon.

Also specify the standard W3C propagation format.

See example output:
```
otel-1  | Span #3
otel-1  |     Trace ID       : 74d5930bd8c0da99c9659c21ca125d29
otel-1  |     Parent ID      : 51c8552ae39e1bc1
otel-1  |     ID             : a39350d12e2aff37
otel-1  |     Name           : DELETE /v1/tenants/{id=*}
otel-1  |     Kind           : Server
otel-1  |     Start time     : 2025-02-25 12:27:47.756203 +0000 UTC
otel-1  |     End time       : 2025-02-25 12:27:47.75641975 +0000 UTC
otel-1  |     Status code    : Unset
otel-1  |     Status message :
otel-1  | Attributes:
otel-1  |      -> http.method: Str(DELETE)
otel-1  |      -> http.scheme: Str(http)
otel-1  |      -> net.host.name: Str(permify)
otel-1  |      -> net.host.port: Int(3476)
otel-1  |      -> net.sock.peer.addr: Str(::1)
otel-1  |      -> net.sock.peer.port: Int(59070)
otel-1  |      -> user_agent.original: Str(ciam)
otel-1  |      -> http.target: Str(/v1/tenants/9067a9-TestRun)
otel-1  |      -> net.protocol.version: Str(1.1)
otel-1  |      -> http.response_content_length: Int(103)
otel-1  |      -> http.status_code: Int(200)
otel-1  |       {"kind": "exporter", "data_type": "traces", "name": "debug"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced request tracing with improved instrumentation, resulting in more accurate monitoring.
  - Improved telemetry with robust context propagation, ensuring reliable trace data across services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->