### PR TITLE
fix(docs): add missing quotes to JSON properties in cURL examples

### DIFF
--- a/docs/api-reference/apidocs.swagger.json
+++ b/docs/api-reference/apidocs.swagger.json
@@ -418,7 +418,7 @@
           {
             "label": "cURL",
             "lang": "curl",
-            "source": "curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/data/attributes/read' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{\n  metadata: {\n    snap_token: \"\",\n  },\n  filter: {\n    entity: {\n      type: \"organization\",\n      ids: [\n        \"1\"\n      ]\n    },\n    attributes: [\n      \"private\"\n    ],\n  }\n}'"
+            "source": "curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/data/attributes/read' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{\n  \"metadata\": {\n    \"snap_token\": \"\"\n  },\n  \"filter\": {\n    \"entity\": {\n      \"type\": \"organization\",\n      \"ids\": [\n        \"1\"\n      ]\n    },\n    \"attributes\": [\n      \"private\"\n    ]\n  }\n}'"
           }
         ]
       }
@@ -532,7 +532,7 @@
           {
             "label": "cURL",
             "lang": "curl",
-            "source": "curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/data/relationships/read' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{\n  metadata: {\n    snap_token: \"\",\n  },\n  filter: {\n    entity: {\n      type: \"organization\",\n      ids: [\n        \"1\"\n      ]\n    },\n    relation: \"member\",\n    subject: {\n      type: \"\",\n      ids: [],\n      relation: \"\"\n    }\n  }\n}'"
+            "source": "curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/data/relationships/read' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{\n  \"metadata\": {\n    \"snap_token\": \"\"\n  },\n  \"filter\": {\n    \"entity\": {\n      \"type\": \"organization\",\n      \"ids\": [\n        \"1\"\n      ]\n    },\n    \"relation\": \"member\",\n    \"subject\": {\n      \"type\": \"\",\n      \"ids\": [],\n      \"relation\": \"\"\n    }\n  }\n}'"
           }
         ]
       }

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -544,7 +544,7 @@
           {
             "label": "cURL",
             "lang": "curl",
-            "source": "curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/data/attributes/read' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{\n  metadata: {\n    snap_token: \"\",\n  },\n  filter: {\n    entity: {\n      type: \"organization\",\n      ids: [\n        \"1\"\n      ]\n    },\n    attributes: [\n      \"private\"\n    ],\n  }\n}'"
+            "source": "curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/data/attributes/read' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{\n  \"metadata\": {\n    \"snap_token\": \"\"\n  },\n  \"filter\": {\n    \"entity\": {\n      \"type\": \"organization\",\n      \"ids\": [\n        \"1\"\n      ]\n    },\n    \"attributes\": [\n      \"private\"\n    ]\n  }\n}'"
           }
         ],
         "x-codegen-request-body-name": "body"
@@ -684,7 +684,7 @@
           {
             "label": "cURL",
             "lang": "curl",
-            "source": "curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/data/relationships/read' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{\n  metadata: {\n    snap_token: \"\",\n  },\n  filter: {\n    entity: {\n      type: \"organization\",\n      ids: [\n        \"1\"\n      ]\n    },\n    relation: \"member\",\n    subject: {\n      type: \"\",\n      ids: [],\n      relation: \"\"\n    }\n  }\n}'"
+            "source": "curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/data/relationships/read' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{\n  \"metadata\": {\n    \"snap_token\": \"\"\n  },\n  \"filter\": {\n    \"entity\": {\n      \"type\": \"organization\",\n      \"ids\": [\n        \"1\"\n      ]\n    },\n    \"relation\": \"member\",\n    \"subject\": {\n      \"type\": \"\",\n      \"ids\": [],\n      \"relation\": \"\"\n    }\n  }\n}'"
           }
         ],
         "x-codegen-request-body-name": "body"

--- a/docs/api-reference/openapiv2/apidocs.swagger.json
+++ b/docs/api-reference/openapiv2/apidocs.swagger.json
@@ -418,7 +418,7 @@
           {
             "label": "cURL",
             "lang": "curl",
-            "source": "curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/data/attributes/read' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{\n  metadata: {\n    snap_token: \"\",\n  },\n  filter: {\n    entity: {\n      type: \"organization\",\n      ids: [\n        \"1\"\n      ]\n    },\n    attributes: [\n      \"private\"\n    ],\n  }\n}'"
+            "source": "curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/data/attributes/read' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{\n  \"metadata\": {\n    \"snap_token\": \"\"\n  },\n  \"filter\": {\n    \"entity\": {\n      \"type\": \"organization\",\n      \"ids\": [\n        \"1\"\n      ]\n    },\n    \"attributes\": [\n      \"private\"\n    ]\n  }\n}'"
           }
         ]
       }
@@ -532,7 +532,7 @@
           {
             "label": "cURL",
             "lang": "curl",
-            "source": "curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/data/relationships/read' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{\n  metadata: {\n    snap_token: \"\",\n  },\n  filter: {\n    entity: {\n      type: \"organization\",\n      ids: [\n        \"1\"\n      ]\n    },\n    relation: \"member\",\n    subject: {\n      type: \"\",\n      ids: [],\n      relation: \"\"\n    }\n  }\n}'"
+            "source": "curl --location --request POST 'localhost:3476/v1/tenants/{tenant_id}/data/relationships/read' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{\n  \"metadata\": {\n    \"snap_token\": \"\"\n  },\n  \"filter\": {\n    \"entity\": {\n      \"type\": \"organization\",\n      \"ids\": [\n        \"1\"\n      ]\n    },\n    \"relation\": \"member\",\n    \"subject\": {\n      \"type\": \"\",\n      \"ids\": [],\n      \"relation\": \"\"\n    }\n  }\n}'"
           }
         ]
       }


### PR DESCRIPTION
Fix some JSON formatting issues found while traversing the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected cURL request examples for POST /v1/tenants/{tenant_id}/data/attributes/read and /v1/tenants/{tenant_id}/data/relationships/read to use valid JSON with quoted keys across Swagger/OpenAPI docs (v2 and v3). Improves copy-paste reliability and reduces request errors.
  * Minor formatting cleanup. No changes to endpoints, parameters, or schemas; API behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->