### PR TITLE
docs: update path and content for migration/repair documentation

### DIFF
--- a/docs/migration/repair.mdx
+++ b/docs/migration/repair.mdx
@@ -1,10 +1,6 @@
 ---
-icon: cog
-title: "Database Repair"
-description: "Repair PostgreSQL XID counter to prevent wraparound issues"
+title: Database Repair
 ---
-
-# Database Repair
 
 The `permify repair datastore` command helps prevent PostgreSQL XID wraparound issues by safely advancing the transaction ID counter. This is essential after database migrations or when dealing with XID-related problems.
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -320,7 +320,6 @@
         "operations/bundle",
         "operations/cache",
         "operations/contextual-tuples",
-        "operations/repair",
         "operations/tracing",
         "operations/snap-tokens"
       ]
@@ -355,7 +354,8 @@
     {
       "group": "Migration",
       "pages": [
-        "migration/v1.0-v1.1"
+        "migration/v1.0-v1.1",
+        "migration/repair"
       ]
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Relocated the “Database Repair” documentation from the Operations section to the Migration section in the docs navigation.
  - Simplified the “Database Repair” page content by removing the introductory sections and headings, leaving a minimal placeholder.
  - Updated metadata to reflect the new placement and presentation.

- Chores
  - Cleaned up documentation structure to improve navigation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->