### PR TITLE
test: add unit tests for pguint64 and Postgres options functionality

### DIFF
--- a/pkg/database/postgres/pguint64_test.go
+++ b/pkg/database/postgres/pguint64_test.go
@@ -168,4 +168,84 @@ var _ = Describe("pguint64", func() {
 			Expect(err.Error()).Should(ContainSubstring("undefined status"))
 		})
 	})
+
+	Context("AssignTo", func() {
+		It("Case 1: Success with *uint64", func() {
+			p := pguint64{Uint: 12345, Status: pgtype.Present}
+			var target uint64
+			err := p.AssignTo(&target)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(target).Should(Equal(uint64(12345)))
+		})
+
+		It("Case 2: Success with **uint64", func() {
+			p := pguint64{Uint: 12345, Status: pgtype.Present}
+			var target *uint64
+			err := p.AssignTo(&target)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(*target).Should(Equal(uint64(12345)))
+		})
+
+		It("Case 3: Success with **uint64 and null status", func() {
+			p := pguint64{Status: pgtype.Null}
+			var target *uint64
+			err := p.AssignTo(&target)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(target).Should(BeNil())
+		})
+
+		It("Case 4: Error with null status and *uint64", func() {
+			p := pguint64{Status: pgtype.Null}
+			var target uint64
+			err := p.AssignTo(&target)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("cannot assign"))
+		})
+
+		It("Case 5: Success with unsupported target type (no error)", func() {
+			p := pguint64{Uint: 12345, Status: pgtype.Present}
+			var target string
+			err := p.AssignTo(&target)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("DecodeBinary", func() {
+		It("Case 1: Null input", func() {
+			var p pguint64
+			err := p.DecodeBinary(nil, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(p.Status).Should(Equal(pgtype.Null))
+		})
+
+		It("Case 2: Invalid input size", func() {
+			var p pguint64
+			err := p.DecodeBinary(nil, []byte{0x01, 0x02})
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("invalid length"))
+		})
+	})
+
+	Context("EncodeBinary", func() {
+		It("Case 1: Present status", func() {
+			p := pguint64{Uint: 12345, Status: pgtype.Present}
+			result, err := p.EncodeBinary(nil, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result).Should(Equal([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39}))
+		})
+
+		It("Case 2: Null status", func() {
+			p := pguint64{Status: pgtype.Null}
+			result, err := p.EncodeBinary(nil, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result).Should(BeNil())
+		})
+
+		It("Case 3: Undefined status", func() {
+			p := pguint64{Status: pgtype.Undefined}
+			_, err := p.EncodeBinary(nil, nil)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("undefined status"))
+		})
+	})
 })

--- a/pkg/database/postgres/xid8_test.go
+++ b/pkg/database/postgres/xid8_test.go
@@ -135,4 +135,84 @@ var _ = Describe("XID8", func() {
 			Expect(result).Should(BeNil())
 		})
 	})
+
+	Context("AssignTo", func() {
+		It("Case 1: Success with *uint64", func() {
+			x := XID8{Uint: 12345, Status: pgtype.Present}
+			var target uint64
+			err := x.AssignTo(&target)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(target).Should(Equal(uint64(12345)))
+		})
+
+		It("Case 2: Success with **uint64", func() {
+			x := XID8{Uint: 12345, Status: pgtype.Present}
+			var target *uint64
+			err := x.AssignTo(&target)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(*target).Should(Equal(uint64(12345)))
+		})
+
+		It("Case 3: Success with **uint64 and null status", func() {
+			x := XID8{Status: pgtype.Null}
+			var target *uint64
+			err := x.AssignTo(&target)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(target).Should(BeNil())
+		})
+
+		It("Case 4: Error with null status and *uint64", func() {
+			x := XID8{Status: pgtype.Null}
+			var target uint64
+			err := x.AssignTo(&target)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("cannot assign"))
+		})
+
+		It("Case 5: Success with unsupported target type (no error)", func() {
+			x := XID8{Uint: 12345, Status: pgtype.Present}
+			var target string
+			err := x.AssignTo(&target)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("DecodeBinary", func() {
+		It("Case 1: Null input", func() {
+			var x XID8
+			err := x.DecodeBinary(nil, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(x.Status).Should(Equal(pgtype.Null))
+		})
+
+		It("Case 2: Invalid input size", func() {
+			var x XID8
+			err := x.DecodeBinary(nil, []byte{0x01, 0x02})
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("invalid length"))
+		})
+	})
+
+	Context("EncodeBinary", func() {
+		It("Case 1: Present status", func() {
+			x := XID8{Uint: 12345, Status: pgtype.Present}
+			result, err := x.EncodeBinary(nil, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result).Should(Equal([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39}))
+		})
+
+		It("Case 2: Null status", func() {
+			x := XID8{Status: pgtype.Null}
+			result, err := x.EncodeBinary(nil, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result).Should(BeNil())
+		})
+
+		It("Case 3: Undefined status", func() {
+			x := XID8{Status: pgtype.Undefined}
+			_, err := x.EncodeBinary(nil, nil)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("undefined status"))
+		})
+	})
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage for Postgres components, including option setters, readiness/close behavior via mocks, and value encoding/decoding and assignment across edge cases (null/undefined, invalid inputs, unsupported targets).
  * Clarifies expected behavior under error conditions and strengthens regression protection.
  * No changes to runtime behavior; improvements focus on reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->