### PR TITLE
refactor(openid): rename package from oidc to openid across files

### DIFF
--- a/internal/authn/openid/adapter.go
+++ b/internal/authn/openid/adapter.go
@@ -1,4 +1,4 @@
-package oidc
+package openid
 
 import (
 	"log/slog"

--- a/internal/authn/openid/adapter_test.go
+++ b/internal/authn/openid/adapter_test.go
@@ -1,4 +1,4 @@
-package oidc
+package openid
 
 import (
 	"bytes"

--- a/internal/authn/openid/authn.go
+++ b/internal/authn/openid/authn.go
@@ -1,4 +1,4 @@
-package oidc
+package openid
 
 import (
 	"context"

--- a/internal/authn/openid/authn_test.go
+++ b/internal/authn/openid/authn_test.go
@@ -1,4 +1,4 @@
-package oidc
+package openid
 
 import (
 	"context"

--- a/internal/authn/openid/fakes_test.go
+++ b/internal/authn/openid/fakes_test.go
@@ -1,4 +1,4 @@
-package oidc
+package openid
 
 import (
 	"crypto/ecdsa"

--- a/internal/authn/openid/oidc_test.go
+++ b/internal/authn/openid/oidc_test.go
@@ -1,4 +1,4 @@
-package oidc
+package openid
 
 import (
 	"testing"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Renamed internal OpenID package to standardize naming for clarity and maintainability. No changes to authentication behavior, APIs, or configuration.

* Tests
  * Updated test packages to match the new naming. Test scenarios and results remain unchanged; build and runtime behavior are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->