### PR TITLE
build: update base image reference in Dockerfile.release

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-ARG BASE=cgr.dev/chainguard/static:latest
+ARG BASE=cgr.dev/chainguard/static:latest@sha256:b00a88ca2a8136cdbd86a8aa834c3f69c17debb295a38055f7babfc2c9f9a02b
 
 # Build stage for gRPC health probe
 FROM golang:1.25.1-alpine3.22@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS health-probe-builder


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the base container image to a fixed digest to improve build reproducibility and supply-chain integrity.
  * Ensures deterministic builds and consistent releases across environments.
  * No changes to features or behavior; runtime and health checks remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->