### PR TITLE
fix: fix concurrency issue: do not merge head snapshot/version requests fr…

### DIFF
--- a/internal/storage/decorators/singleflight/data_reader.go
+++ b/internal/storage/decorators/singleflight/data_reader.go
@@ -54,7 +54,7 @@ func (r *DataReader) QueryUniqueSubjectReferences(ctx context.Context, tenantID 
 
 // HeadSnapshot - Reads the latest version of the snapshot from the repository.
 func (r *DataReader) HeadSnapshot(ctx context.Context, tenantID string) (token.SnapToken, error) {
-	rev, _, err := r.group.Do(ctx, "", func(ctx context.Context) (token.SnapToken, error) {
+	rev, _, err := r.group.Do(ctx, tenantID, func(ctx context.Context) (token.SnapToken, error) {
 		return r.delegate.HeadSnapshot(ctx, tenantID)
 	})
 	return rev, err

--- a/internal/storage/decorators/singleflight/schema_reader.go
+++ b/internal/storage/decorators/singleflight/schema_reader.go
@@ -43,7 +43,7 @@ func (r *SchemaReader) ReadRuleDefinition(ctx context.Context, tenantID, ruleNam
 
 // HeadVersion - Finds the latest version of the schema.
 func (r *SchemaReader) HeadVersion(ctx context.Context, tenantID string) (version string, err error) {
-	rev, _, err := r.group.Do(ctx, "", func(ctx context.Context) (string, error) {
+	rev, _, err := r.group.Do(ctx, tenantID, func(ctx context.Context) (string, error) {
 		return r.delegate.HeadVersion(ctx, tenantID)
 	})
 	return rev, err


### PR DESCRIPTION
…om different tenants.

May be related to https://github.com/Permify/permify/issues/2573.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated request deduplication to operate on a per-tenant basis rather than globally, affecting how concurrent requests are handled in multi-tenant scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->