### PR TITLE
docs: update terminology from "entities" to "partials" in schema refe…

### DIFF
--- a/docs/api-reference/schema/partial-write.mdx
+++ b/docs/api-reference/schema/partial-write.mdx
@@ -26,7 +26,7 @@ body:
   "metadata": {
     "schema_version": ""
   },
-  "entities": {
+  "partials": {
 		"<entity-name>": {
 			"write": [],
 			"delete": [],
@@ -79,7 +79,7 @@ To update the **`team`** entity by introducing new permissions, the following PA
   "metadata": {
     "schema_version": ""
   },
-  "entities": {
+  "partials": {
 		"team": {
 		  "write": [
 		    "relation member @user",


### PR DESCRIPTION
…rence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated partial-write API payload reference to use "partials" as the top-level key instead of "entities". Inner structure and functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->