### PR TITLE
docs: fix entity linking character

### DIFF
--- a/docs/use-cases/rebac.mdx
+++ b/docs/use-cases/rebac.mdx
@@ -125,7 +125,7 @@ entity repository {
 } 
 ```
 
-Since `parent` represents the parent organization of a repository, it can reach the repository's parent organization relations with a comma. So, 
+Since `parent` represents the parent organization of a repository, it can reach the repository's parent organization relations with a period (`.`). So, 
 
 - ``parent.admin``
 indicates admin role on organization


### PR DESCRIPTION
change to reference a period, not a comma, for linking across entities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated relation access syntax in the ReBAC use case documentation to use period (`.`) for parent relation access instead of comma (`,`).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->