### PR TITLE
docs(analytics): added in google analytics tracking

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -31,6 +31,9 @@
   "analytics": {
     "plausible": {
       "domain": "docs.permify.co"
+    },
+    "ga4": {
+      "measurementId": "G-BSRXWHBYR1"
     }
   },
   "topbarCtaButton": {


### PR DESCRIPTION
This leverages existing Google Analytics account to offer analytics for permify docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured GA4 analytics tracking alongside existing analytics settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->