### PR TITLE
feat: add permission condition coverage to coverage command

### DIFF
--- a/pkg/cmd/coverage.go
+++ b/pkg/cmd/coverage.go
@@ -157,5 +157,46 @@ func DisplayCoverageInfo(schemaCoverageInfo cov.SchemaCoverageInfo) {
 				color.Success.Printf(" %d%%\n", value)
 			}
 		}
+
+		// Display permission condition coverage
+		displayConditionCoverage(entityCoverageInfo)
+	}
+}
+
+// displayConditionCoverage displays the detailed condition-level coverage for each permission
+func displayConditionCoverage(entityCoverageInfo cov.EntityCoverageInfo) {
+	if len(entityCoverageInfo.PermissionConditionCoverage) == 0 {
+		return
+	}
+
+	fmt.Printf("  permission condition coverage:\n")
+
+	for scenarioName, permCoverages := range entityCoverageInfo.PermissionConditionCoverage {
+		fmt.Printf("    %s:\n", scenarioName)
+
+		for permName, condCov := range permCoverages {
+			fmt.Printf("      %s:", permName)
+
+			if condCov.CoveragePercent <= 50 {
+				color.Danger.Printf(" %d%% (%d/%d components)\n",
+					condCov.CoveragePercent,
+					len(condCov.CoveredComponents),
+					len(condCov.AllComponents),
+				)
+			} else {
+				color.Success.Printf(" %d%% (%d/%d components)\n",
+					condCov.CoveragePercent,
+					len(condCov.CoveredComponents),
+					len(condCov.AllComponents),
+				)
+			}
+
+			if len(condCov.UncoveredComponents) > 0 {
+				fmt.Printf("        uncovered components:\n")
+				for _, comp := range condCov.UncoveredComponents {
+					fmt.Printf("          - %s (%s)\n", comp.Name, comp.Type)
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds detailed condition-level coverage analysis to the `coverage` command
- Walks each permission's condition tree (union, intersection, exclusion) and reports which leaf components (relations, attributes, computed usersets) are covered by test data
- New types: `ConditionComponent`, `ConditionCoverageInfo` for tracking individual condition components
- Adds `PermissionConditionCoverage` field to `EntityCoverageInfo` mapping scenario → permission → condition coverage
- CLI output shows per-permission condition coverage percentages with uncovered component details

## Changes

- `pkg/development/coverage/coverage.go`: New condition coverage types and `calculateConditionCoverage()` function that extracts leaf components from permission condition trees and checks coverage against test data
- `pkg/cmd/coverage.go`: New `displayConditionCoverage()` function for CLI output with color-coded percentages

## Test plan

- [ ] Run `go build ./...` to verify compilation
- [ ] Run existing coverage tests to ensure no regression
- [ ] Test with example schema files that have complex permission conditions (union/intersection/exclusion)
- [ ] Verify CLI output shows condition coverage for each asserted permission

/claim #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced coverage reports now display detailed permission condition coverage metrics
  * Color-coded coverage percentages provide visual clarity (red for ≤50%, green for higher coverage)
  * Uncovered components are now identified and listed in coverage analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->