### PR TITLE
fix: remove shares prefix from blob uploads

### DIFF
--- a/playground/blob-upload.js
+++ b/playground/blob-upload.js
@@ -1,5 +1,3 @@
-import {SHARE_PATH_PREFIX} from './src/utility/helpers/blob-upload.js';
-
 export const MAX_SHARE_FILE_SIZE_BYTES = 1024 * 1024;
 export const SHARE_ALLOWED_CONTENT_TYPES = [
   'text/yaml',
@@ -11,7 +9,7 @@ export const SHARE_ALLOWED_CONTENT_TYPES = [
 ];
 
 function isValidSharePathname(pathname) {
-  return new RegExp(`^${SHARE_PATH_PREFIX}[A-Za-z0-9-]+\\.ya?ml$`).test(pathname);
+  return /^[A-Za-z0-9-]+\.ya?ml$/.test(pathname);
 }
 
 function getHeader(request, name) {

--- a/playground/src/layout/main-layout.js
+++ b/playground/src/layout/main-layout.js
@@ -7,7 +7,7 @@ import yaml from "js-yaml";
 import {useShapeStore} from "@state/shape";
 import Share from "@components/modals/share";
 import toast, {Toaster} from 'react-hot-toast';
-import {BLOB_UPLOAD_ROUTE, SHARE_PATH_PREFIX} from "@utility/helpers/blob-upload";
+import {BLOB_UPLOAD_ROUTE} from "@utility/helpers/blob-upload";
 
 const {Option, OptGroup} = Select;
 const {Content} = Layout;
@@ -64,7 +64,7 @@ const MainLayout = ({children, ...rest}) => {
             const uniqueId = `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
             const fileName = `${uniqueId}.yaml`;
             const file = new File([yamlString], fileName, {type: 'text/x-yaml'});
-            upload(`${SHARE_PATH_PREFIX}${fileName}`, file, {
+            upload(fileName, file, {
                 access: 'public',
                 handleUploadUrl: BLOB_UPLOAD_ROUTE,
             }).then((result) => {

--- a/playground/src/utility/helpers/blob-upload.js
+++ b/playground/src/utility/helpers/blob-upload.js
@@ -1,2 +1,1 @@
 export const BLOB_UPLOAD_ROUTE = '/api/blob/upload';
-export const SHARE_PATH_PREFIX = 'shares/';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified upload path validation. Removed prefix requirement from share upload pathnames, allowing more flexible file naming conventions while maintaining validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->