### PR TITLE
docs: remove busted roadmap link

### DIFF
--- a/docs/permify-overview/intro.mdx
+++ b/docs/permify-overview/intro.mdx
@@ -90,10 +90,6 @@ For feature requests, bugs, or any improvements you can always open an [issue](h
 
 You can find more details about contributions on [CONTRIBUTING.md](https://github.com/Permify/permify/blob/master/CONTRIBUTING.md).
 
-## Roadmap
-
-You can find Permify's Public Roadmap [here](https://permify.featurebase.app/)!
-
 ## Build Fine Grained Authorization for Your Company
 
 Our team is happy to help you get started with Permify. 


### PR DESCRIPTION
This link doesn't work, so remove it and the section around it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Roadmap section from the introduction documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->