### PR TITLE
feat: allow overriding service name in tracer, meter, and logger config

### DIFF
--- a/docs/setting-up/configuration.mdx
+++ b/docs/setting-up/configuration.mdx
@@ -199,21 +199,24 @@ Real time logs of authorization. Permify uses [zerolog] as a logger.
 ```
 ├── logger
     ├── level
+    ├── service_name
 ```
 
 #### Glossary
 
-| Required | Argument | Default | Description                                      |
-|----------|----------|---------|--------------------------------------------------|
-| [x]      | level    | info    | logger levels: `error`, `warn`, `info` , `debug` |
-| [x]      | output   | text    | logger output: `json`, `text`                    |
+| Required | Argument     | Default | Description                                              |
+|----------|--------------|---------|----------------------------------------------------------|
+| [x]      | level        | info    | logger levels: `error`, `warn`, `info` , `debug`         |
+| [x]      | output       | text    | logger output: `json`, `text`                            |
+| [ ]      | service_name | permify | Override the service name reported by the log exporter.   |
 
 #### ENV
 
-| Argument   | ENV                | Type   |
-|------------|--------------------|--------|
-| log-level  | PERMIFY_LOG_LEVEL  | string |
-| log-output | PERMIFY_LOG_OUTPUT | string |
+| Argument          | ENV                       | Type   |
+|-------------------|---------------------------|--------|
+| log-level         | PERMIFY_LOG_LEVEL         | string |
+| log-output        | PERMIFY_LOG_OUTPUT        | string |
+| log-service-name  | PERMIFY_LOG_SERVICE_NAME  | string |
 
 </Accordion>
 
@@ -330,6 +333,7 @@ authorization when using Permify.
 |   ├── enabled
 |   ├── insecure
 |   ├── urlpath
+|   ├── service_name
 ```
 
 #### Glossary
@@ -340,17 +344,19 @@ authorization when using Permify.
 | [x]      | endpoint | -       | export uri for tracing data.                                                                                                  |
 | [ ]      | enabled  | false   | switch option for tracing.                                                                                                    |
 | [ ]      | urlpath  |         | allows one to override the default URL path for otlp, used for sending traces. If unset, default ("/v1/traces") will be used. |
-| [ ]      | insecure | false   | Whether to use HTTP instead of HTTPs for exporting the traces.                                                                |
+| [ ]      | insecure     | false   | Whether to use HTTP instead of HTTPs for exporting the traces.                                                                |
+| [ ]      | service_name | permify | Override the service name reported by the tracing exporter.                                                                   |
 
 #### ENV
 
-| Argument        | ENV                     | Type    |
-|-----------------|-------------------------|---------|
-| tracer-enabled  | PERMIFY_TRACER_ENABLED  | boolean |
-| tracer-exporter | PERMIFY_TRACER_EXPORTER | string  |
-| tracer-endpoint | PERMIFY_TRACER_ENDPOINT | string  |
-| tracer-urlpath  | PERMIFY_TRACER_URL_PATH | string  |
-| tracer-insecure | PERMIFY_TRACER_INSECURE | boolean |
+| Argument             | ENV                          | Type    |
+|----------------------|------------------------------|---------|
+| tracer-enabled       | PERMIFY_TRACER_ENABLED       | boolean |
+| tracer-exporter      | PERMIFY_TRACER_EXPORTER      | string  |
+| tracer-endpoint      | PERMIFY_TRACER_ENDPOINT      | string  |
+| tracer-urlpath       | PERMIFY_TRACER_URL_PATH      | string  |
+| tracer-insecure      | PERMIFY_TRACER_INSECURE      | boolean |
+| tracer-service-name  | PERMIFY_TRACER_SERVICE_NAME  | string  |
 
 </Accordion>
 
@@ -370,6 +376,7 @@ os, arch.
 |   ├── enabled
 |   ├── insecure
 |   ├── urlpath
+|   ├── service_name
 ```
 
 #### Glossary
@@ -377,18 +384,20 @@ os, arch.
 | Required | Argument | Default | Description                                                  |
 |----------|----------|---------|--------------------------------------------------------------|
 | [x]      | exporter | -       | [otlp](https://opentelemetry.io/docs/collector/) is default. |
-| [x]      | endpoint | -       | export uri for metric observation                            |
-| [ ]      | enabled  | true    | switch option for meter tracing.                             |
+| [x]      | endpoint     | -       | export uri for metric observation                                            |
+| [ ]      | enabled      | true    | switch option for meter tracing.                                             |
+| [ ]      | service_name | permify | Override the service name reported by the metrics exporter.                  |
 
 #### ENV
 
-| Argument       | ENV                    | Type    |
-|----------------|------------------------|---------|
-| meter-enabled  | PERMIFY_METER_ENABLED  | boolean |
-| meter-exporter | PERMIFY_METER_EXPORTER | string  |
-| meter-endpoint | PERMIFY_METER_ENDPOINT | string  |
-| meter-urlpath  | PERMIFY_METER_URL_PATH | string  |
-| meter-insecure | PERMIFY_METER_INSECURE | boolean |
+| Argument            | ENV                         | Type    |
+|---------------------|-----------------------------|---------|
+| meter-enabled       | PERMIFY_METER_ENABLED       | boolean |
+| meter-exporter      | PERMIFY_METER_EXPORTER      | string  |
+| meter-endpoint      | PERMIFY_METER_ENDPOINT      | string  |
+| meter-urlpath       | PERMIFY_METER_URL_PATH      | string  |
+| meter-insecure      | PERMIFY_METER_INSECURE      | boolean |
+| meter-service-name  | PERMIFY_METER_SERVICE_NAME  | string  |
 
 </Accordion>
 

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -45,6 +45,7 @@ tracer:
   exporter: zipkin
   endpoint: http://localhost:9411/api/v2/spans
   enabled: false
+  service_name: permify
 
 # The meter section enables or disables metrics collection and sets the
 # exporter and endpoint for the collected metrics.
@@ -52,6 +53,7 @@ meter:
   exporter: otlp
   endpoint: localhost:4318
   enabled: false
+  service_name: permify
 
 # The service section sets various service-level settings, including whether
 # or not to use a circuit breaker, and cache sizes for schema, permission,
@@ -79,16 +81,16 @@ database:
   engine: postgres
   uri: postgres://user:password@host:5432/db_name
   auto_migrate: false
-  max_connections: 20  # Maximum number of connections in the pool (maps to pgxpool MaxConns)
-  max_open_connections: 20  # Deprecated: use max_connections instead. Kept for backward compatibility.
-  max_idle_connections: 1  # Deprecated: use min_connections instead. Kept for backward compatibility (maps to MinConnections if min_connections is not set).
-  min_connections: 0  # Minimum number of connections in the pool (maps to pgxpool MinConns). If 0 and max_idle_connections is set, max_idle_connections will be used.
-  min_idle_connections: 0  # Minimum idle connections (maps to pgxpool MinIdleConns). Must be explicitly set if needed (not set in old code).
+  max_connections: 20 # Maximum number of connections in the pool (maps to pgxpool MaxConns)
+  max_open_connections: 20 # Deprecated: use max_connections instead. Kept for backward compatibility.
+  max_idle_connections: 1 # Deprecated: use min_connections instead. Kept for backward compatibility (maps to MinConnections if min_connections is not set).
+  min_connections: 0 # Minimum number of connections in the pool (maps to pgxpool MinConns). If 0 and max_idle_connections is set, max_idle_connections will be used.
+  min_idle_connections: 0 # Minimum idle connections (maps to pgxpool MinIdleConns). Must be explicitly set if needed (not set in old code).
   max_connection_lifetime: 300s
   max_connection_idle_time: 60s
-  health_check_period: 0s  # Use pgxpool default (1 minute) if 0
-  max_connection_lifetime_jitter: 0s  # Will default to 20% of max_connection_lifetime if 0
-  connect_timeout: 0s  # Use pgx default (no timeout) if 0
+  health_check_period: 0s # Use pgxpool default (1 minute) if 0
+  max_connection_lifetime_jitter: 0s # Will default to 20% of max_connection_lifetime if 0
+  connect_timeout: 0s # Use pgx default (no timeout) if 0
   max_data_per_write: 1_000
   max_retries: 10
   watch_buffer_size: 100

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,38 +89,41 @@ type (
 
 	// Log contains configuration for logging.
 	Log struct {
-		Level    string   `mapstructure:"level"`    // Logging level
-		Output   string   `mapstructure:"output"`   // Logging output format, e.g., text, json
-		Enabled  bool     `mapstructure:"enabled"`  // Whether logging collection is enabled
-		Exporter string   `mapstructure:"exporter"` // Exporter for log data
-		Endpoint string   `mapstructure:"endpoint"` // Endpoint for the log exporter
-		Insecure bool     `mapstructure:"insecure"` // Connect to the collector using the HTTP scheme, instead of HTTPS.
-		Urlpath  string   `mapstructure:"urlpath"`  // Path for the log exporter, if not defined /v1/logs will be used
-		Headers  []string `mapstructure:"headers"`
-		Protocol string   `mapstructure:"protocol"` // Protocol for the log exporter, http or grpc
+		Level       string   `mapstructure:"level"`    // Logging level
+		Output      string   `mapstructure:"output"`   // Logging output format, e.g., text, json
+		Enabled     bool     `mapstructure:"enabled"`  // Whether logging collection is enabled
+		Exporter    string   `mapstructure:"exporter"` // Exporter for log data
+		Endpoint    string   `mapstructure:"endpoint"` // Endpoint for the log exporter
+		Insecure    bool     `mapstructure:"insecure"` // Connect to the collector using the HTTP scheme, instead of HTTPS.
+		Urlpath     string   `mapstructure:"urlpath"`  // Path for the log exporter, if not defined /v1/logs will be used
+		Headers     []string `mapstructure:"headers"`
+		Protocol    string   `mapstructure:"protocol"`     // Protocol for the log exporter, http or grpc
+		ServiceName string   `mapstructure:"service_name"` // Override the service name reported by the exporter (default: "permify")
 	}
 
 	// Tracer contains configuration for distributed tracing.
 	Tracer struct {
-		Enabled  bool     `mapstructure:"enabled"`  // Whether tracing collection is enabled
-		Exporter string   `mapstructure:"exporter"` // Exporter for tracing data
-		Endpoint string   `mapstructure:"endpoint"` // Endpoint for the tracing exporter
-		Insecure bool     `mapstructure:"insecure"` // Connect to the collector using the HTTP scheme, instead of HTTPS.
-		Urlpath  string   `mapstructure:"urlpath"`  // Path for the tracing exporter, if not defined /v1/trace will be used
-		Headers  []string `mapstructure:"headers"`
-		Protocol string   `mapstructure:"protocol"` // Protocol for the tracing exporter, http or grpc
+		Enabled     bool     `mapstructure:"enabled"`  // Whether tracing collection is enabled
+		Exporter    string   `mapstructure:"exporter"` // Exporter for tracing data
+		Endpoint    string   `mapstructure:"endpoint"` // Endpoint for the tracing exporter
+		Insecure    bool     `mapstructure:"insecure"` // Connect to the collector using the HTTP scheme, instead of HTTPS.
+		Urlpath     string   `mapstructure:"urlpath"`  // Path for the tracing exporter, if not defined /v1/trace will be used
+		Headers     []string `mapstructure:"headers"`
+		Protocol    string   `mapstructure:"protocol"`     // Protocol for the tracing exporter, http or grpc
+		ServiceName string   `mapstructure:"service_name"` // Override the service name reported by the exporter (default: "permify")
 	}
 
 	// Meter contains configuration for metrics collection and reporting.
 	Meter struct {
-		Enabled  bool     `mapstructure:"enabled"`  // Whether metrics collection is enabled
-		Exporter string   `mapstructure:"exporter"` // Exporter for metrics data
-		Endpoint string   `mapstructure:"endpoint"` // Endpoint for the metrics exporter
-		Insecure bool     `mapstructure:"insecure"` // Connect to the collector using the HTTP scheme, instead of HTTPS.
-		Urlpath  string   `mapstructure:"urlpath"`  // Path for the metrics exporter, if not defined /v1/metrics will be used
-		Headers  []string `mapstructure:"headers"`
-		Interval int      `mapstructure:"interval"`
-		Protocol string   `mapstructure:"protocol"` // Protocol for the metrics exporter, http or grpc
+		Enabled     bool     `mapstructure:"enabled"`  // Whether metrics collection is enabled
+		Exporter    string   `mapstructure:"exporter"` // Exporter for metrics data
+		Endpoint    string   `mapstructure:"endpoint"` // Endpoint for the metrics exporter
+		Insecure    bool     `mapstructure:"insecure"` // Connect to the collector using the HTTP scheme, instead of HTTPS.
+		Urlpath     string   `mapstructure:"urlpath"`  // Path for the metrics exporter, if not defined /v1/metrics will be used
+		Headers     []string `mapstructure:"headers"`
+		Interval    int      `mapstructure:"interval"`
+		Protocol    string   `mapstructure:"protocol"`     // Protocol for the metrics exporter, http or grpc
+		ServiceName string   `mapstructure:"service_name"` // Override the service name reported by the exporter (default: "permify")
 	}
 
 	// Service contains configuration for various service-level features.
@@ -308,24 +311,27 @@ func DefaultConfig() *Config {
 			Enabled: false,
 		},
 		Log: Log{
-			Level:    "info",
-			Enabled:  false,
-			Exporter: "otlp",
-			Headers:  []string{},
-			Protocol: "http",
+			Level:       "info",
+			Enabled:     false,
+			Exporter:    "otlp",
+			Headers:     []string{},
+			Protocol:    "http",
+			ServiceName: "permify",
 		},
 		Tracer: Tracer{
-			Enabled:  false,
-			Headers:  []string{},
-			Protocol: "http",
+			Enabled:     false,
+			Headers:     []string{},
+			Protocol:    "http",
+			ServiceName: "permify",
 		},
 		Meter: Meter{
-			Enabled:  false,
-			Exporter: "otlp",
-			Endpoint: "telemetry.permify.co",
-			Headers:  []string{},
-			Interval: 300,
-			Protocol: "http",
+			Enabled:     false,
+			Exporter:    "otlp",
+			Endpoint:    "telemetry.permify.co",
+			Headers:     []string{},
+			Interval:    300,
+			Protocol:    "http",
+			ServiceName: "permify",
 		},
 		Service: Service{
 			CircuitBreaker: false,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -207,6 +207,39 @@ logger:
 	assert.Equal(t, "debug", cfg.Log.Level)        // Log level
 }
 
+func TestDefaultConfig_ServiceName(t *testing.T) {
+	cfg := DefaultConfig()
+	assert.Equal(t, "permify", cfg.Tracer.ServiceName)
+	assert.Equal(t, "permify", cfg.Meter.ServiceName)
+	assert.Equal(t, "permify", cfg.Log.ServiceName)
+}
+
+func TestNewConfigWithFile_ServiceName(t *testing.T) {
+	configContent := []byte(`
+tracer:
+  service_name: "new-service-name"
+meter:
+  service_name: "new-service-name"
+logger:
+  service_name: "new-service-name"
+`)
+
+	tmpDir, err := os.MkdirTemp("", "service-name-config-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	tmpFile := filepath.Join(tmpDir, "config.yaml")
+	err = os.WriteFile(tmpFile, configContent, 0o666)
+	require.NoError(t, err)
+
+	cfg, err := NewConfigWithFile(tmpFile)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equal(t, "new-service-name", cfg.Tracer.ServiceName)
+	assert.Equal(t, "new-service-name", cfg.Meter.ServiceName)
+	assert.Equal(t, "new-service-name", cfg.Log.ServiceName)
+}
+
 // TestNewConfigWithFile_InvalidConfig tests invalid config handling
 func TestNewConfigWithFile_InvalidConfig(t *testing.T) { // Test invalid config
 	configContent := []byte(` 

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -182,6 +182,7 @@ func conf() func(cmd *cobra.Command, args []string) error { // Return config han
 			[]string{"logger.urlpath", cfg.Log.Urlpath, getKeyOrigin(cmd, "log-urlpath", "PERMIFY_LOG_URL_PATH")},
 			[]string{"logger.headers", fmt.Sprintf("%v", cfg.Log.Headers), getKeyOrigin(cmd, "log-headers", "PERMIFY_LOG_HEADERS")},
 			[]string{"logger.protocol", cfg.Log.Protocol, getKeyOrigin(cmd, "log-protocol", "PERMIFY_LOG_PROTOCOL")},
+			[]string{"logger.service_name", cfg.Log.ServiceName, getKeyOrigin(cmd, "log-service-name", "PERMIFY_LOG_SERVICE_NAME")},
 			// AUTHN
 			[]string{"authn.enabled", fmt.Sprintf("%v", cfg.Authn.Enabled), getKeyOrigin(cmd, "authn-enabled", "PERMIFY_AUTHN_ENABLED")},
 			[]string{"authn.method", cfg.Authn.Method, getKeyOrigin(cmd, "authn-method", "PERMIFY_AUTHN_METHOD")},
@@ -201,6 +202,7 @@ func conf() func(cmd *cobra.Command, args []string) error { // Return config han
 			[]string{"tracer.urlpath", cfg.Tracer.Urlpath, getKeyOrigin(cmd, "tracer-urlpath", "PERMIFY_TRACER_URL_PATH")},
 			[]string{"tracer.headers", fmt.Sprintf("%v", cfg.Tracer.Headers), getKeyOrigin(cmd, "tracer-headers", "PERMIFY_TRACER_HEADERS")},
 			[]string{"tracer.protocol", cfg.Tracer.Protocol, getKeyOrigin(cmd, "tracer-protocol", "PERMIFY_TRACER_PROTOCOL")},
+			[]string{"tracer.service_name", cfg.Tracer.ServiceName, getKeyOrigin(cmd, "tracer-service-name", "PERMIFY_TRACER_SERVICE_NAME")},
 			// METER
 			[]string{"meter.enabled", fmt.Sprintf("%v", cfg.Meter.Enabled), getKeyOrigin(cmd, "meter-enabled", "PERMIFY_METER_ENABLED")},
 			[]string{"meter.exporter", cfg.Meter.Exporter, getKeyOrigin(cmd, "meter-exporter", "PERMIFY_METER_EXPORTER")},
@@ -210,6 +212,7 @@ func conf() func(cmd *cobra.Command, args []string) error { // Return config han
 			[]string{"meter.headers", fmt.Sprintf("%v", cfg.Meter.Headers), getKeyOrigin(cmd, "meter-headers", "PERMIFY_METER_HEADERS")},
 			[]string{"meter.protocol", cfg.Meter.Protocol, getKeyOrigin(cmd, "meter-protocol", "PERMIFY_METER_PROTOCOL")},
 			[]string{"meter.interval", fmt.Sprintf("%v", cfg.Meter.Interval), getKeyOrigin(cmd, "meter-interval", "PERMIFY_METER_INTERVAL")},
+			[]string{"meter.service_name", cfg.Meter.ServiceName, getKeyOrigin(cmd, "meter-service-name", "PERMIFY_METER_SERVICE_NAME")},
 			// SERVICE
 			[]string{"service.circuit_breaker", fmt.Sprintf("%v", cfg.Service.CircuitBreaker), getKeyOrigin(cmd, "service-circuit-breaker", "PERMIFY_SERVICE_CIRCUIT_BREAKER")},
 			[]string{"service.schema.cache.number_of_counters", fmt.Sprintf("%v", cfg.Service.Schema.Cache.NumberOfCounters), getKeyOrigin(cmd, "service-schema-cache-number-of-counters", "PERMIFY_SERVICE_WATCH_ENABLED")},

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -54,6 +54,7 @@ func NewConfigCommand() *cobra.Command {
 	f.String("log-urlpath", conf.Log.Urlpath, "allow to set url path for otlp exporter")
 	f.StringSlice("log-headers", conf.Log.Headers, "allows setting custom headers for the log exporter in key-value pairs")
 	f.String("log-protocol", conf.Log.Protocol, "allows setting the communication protocol for the log exporter, with options http or grpc")
+	f.String("log-service-name", conf.Log.ServiceName, "service name for the log exporter")
 	f.Bool("authn-enabled", conf.Authn.Enabled, "enable server authentication")
 	f.String("authn-method", conf.Authn.Method, "server authentication method")
 	f.StringSlice("authn-preshared-keys", conf.Authn.Preshared.Keys, "preshared key/keys for server authentication")
@@ -71,6 +72,7 @@ func NewConfigCommand() *cobra.Command {
 	f.String("tracer-urlpath", conf.Tracer.Urlpath, "allow to set url path for otlp exporter")
 	f.StringSlice("tracer-headers", conf.Tracer.Headers, "allows setting custom headers for the tracer exporter in key-value pairs")
 	f.String("tracer-protocol", conf.Tracer.Protocol, "allows setting the communication protocol for the tracer exporter, with options http or grpc")
+	f.String("tracer-service-name", conf.Tracer.ServiceName, "service name for the tracer exporter")
 	f.Bool("meter-enabled", conf.Meter.Enabled, "switch option for metric")
 	f.String("meter-exporter", conf.Meter.Exporter, "can be; otlp. (integrated metric tools)")
 	f.String("meter-endpoint", conf.Meter.Endpoint, "export uri for metric data")
@@ -79,6 +81,7 @@ func NewConfigCommand() *cobra.Command {
 	f.StringSlice("meter-headers", conf.Meter.Headers, "allows setting custom headers for the metric exporter in key-value pairs")
 	f.Int("meter-interval", conf.Meter.Interval, "allows to set metrics to be pushed in certain time interval") // Metric push interval
 	f.String("meter-protocol", conf.Meter.Protocol, "allows setting the communication protocol for the meter exporter, with options http or grpc")
+	f.String("meter-service-name", conf.Meter.ServiceName, "service name for the meter exporter")
 	f.Bool("service-circuit-breaker", conf.Service.CircuitBreaker, "switch option for service circuit breaker")
 	f.Bool("service-watch-enabled", conf.Service.Watch.Enabled, "switch option for watch service")
 	f.Int64("service-schema-cache-number-of-counters", conf.Service.Schema.Cache.NumberOfCounters, "schema service cache number of counters")

--- a/pkg/cmd/flags/serve.go
+++ b/pkg/cmd/flags/serve.go
@@ -208,6 +208,13 @@ func RegisterServeFlags(flags *pflag.FlagSet) {
 		panic(err)
 	}
 
+	if err = viper.BindPFlag("logger.service_name", flags.Lookup("log-service-name")); err != nil {
+		panic(err)
+	}
+	if err = viper.BindEnv("logger.service_name", "PERMIFY_LOG_SERVICE_NAME"); err != nil {
+		panic(err)
+	}
+
 	// AUTHN - Authentication configuration flags
 	if err = viper.BindPFlag("authn.enabled", flags.Lookup("authn-enabled")); err != nil {
 		panic(err)
@@ -329,6 +336,13 @@ func RegisterServeFlags(flags *pflag.FlagSet) {
 		panic(err)
 	}
 
+	if err = viper.BindPFlag("tracer.service_name", flags.Lookup("tracer-service-name")); err != nil {
+		panic(err)
+	}
+	if err = viper.BindEnv("tracer.service_name", "PERMIFY_TRACER_SERVICE_NAME"); err != nil {
+		panic(err)
+	}
+
 	// METER
 	if err = viper.BindPFlag("meter.enabled", flags.Lookup("meter-enabled")); err != nil {
 		panic(err)
@@ -383,6 +397,13 @@ func RegisterServeFlags(flags *pflag.FlagSet) {
 		panic(err)
 	}
 	if err = viper.BindEnv("meter.protocol", "PERMIFY_METER_PROTOCOL"); err != nil {
+		panic(err)
+	}
+
+	if err = viper.BindPFlag("meter.service_name", flags.Lookup("meter-service-name")); err != nil {
+		panic(err)
+	}
+	if err = viper.BindEnv("meter.service_name", "PERMIFY_METER_SERVICE_NAME"); err != nil {
 		panic(err)
 	}
 

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -84,6 +84,7 @@ func NewServeCommand() *cobra.Command {
 	f.String("log-urlpath", conf.Log.Urlpath, "allow to set url path for otlp exporter")
 	f.StringSlice("log-headers", conf.Log.Headers, "allows setting custom headers for the log exporter in key-value pairs")
 	f.String("log-protocol", conf.Log.Protocol, "allows setting the communication protocol for the log exporter, with options http or grpc")
+	f.String("log-service-name", conf.Log.ServiceName, "override the service name reported by the log exporter")
 	f.Bool("authn-enabled", conf.Authn.Enabled, "enable server authentication")
 	f.String("authn-method", conf.Authn.Method, "server authentication method")
 	f.StringSlice("authn-preshared-keys", conf.Authn.Preshared.Keys, "preshared key/keys for server authentication")
@@ -101,6 +102,7 @@ func NewServeCommand() *cobra.Command {
 	f.String("tracer-urlpath", conf.Tracer.Urlpath, "allow to set url path for otlp exporter")
 	f.StringSlice("tracer-headers", conf.Tracer.Headers, "allows setting custom headers for the tracer exporter in key-value pairs")
 	f.String("tracer-protocol", conf.Tracer.Protocol, "allows setting the communication protocol for the tracer exporter, with options http or grpc")
+	f.String("tracer-service-name", conf.Tracer.ServiceName, "override the service name reported by the tracing exporter")
 	f.Bool("meter-enabled", conf.Meter.Enabled, "switch option for metric")
 	f.String("meter-exporter", conf.Meter.Exporter, "can be; otlp. (integrated metric tools)")
 	f.String("meter-endpoint", conf.Meter.Endpoint, "export uri for metric data")
@@ -109,6 +111,7 @@ func NewServeCommand() *cobra.Command {
 	f.StringSlice("meter-headers", conf.Meter.Headers, "allows setting custom headers for the metric exporter in key-value pairs")
 	f.Int("meter-interval", conf.Meter.Interval, "allows to set metrics to be pushed in certain time interval")
 	f.String("meter-protocol", conf.Meter.Protocol, "allows setting the communication protocol for the meter exporter, with options http or grpc")
+	f.String("meter-service-name", conf.Meter.ServiceName, "override the service name reported by the metrics exporter")
 	f.Bool("service-circuit-breaker", conf.Service.CircuitBreaker, "switch option for service circuit breaker")
 	f.Bool("service-watch-enabled", conf.Service.Watch.Enabled, "switch option for watch service")
 	f.Int64("service-schema-cache-number-of-counters", conf.Service.Schema.Cache.NumberOfCounters, "schema service cache number of counters")
@@ -233,6 +236,7 @@ func serve() func(cmd *cobra.Command, args []string) error {
 				headers,
 				cfg.Log.Protocol,
 				getLogLevel(cfg.Log.Level),
+				cfg.Log.ServiceName,
 			)
 			if err != nil {
 				slog.Error("invalid logger exporter", slog.Any("error", err))
@@ -311,7 +315,7 @@ func serve() func(cmd *cobra.Command, args []string) error {
 			}
 
 			// Initialize tracer
-			shutdown := telemetry.NewTracer(exporter) // Create tracer
+			shutdown := telemetry.NewTracer(exporter, cfg.Tracer.ServiceName) // Create tracer
 
 			defer func() {
 				if err = shutdown(ctx); err != nil {
@@ -366,7 +370,7 @@ func serve() func(cmd *cobra.Command, args []string) error {
 			}
 
 			// Initialize meter
-			shutdown := telemetry.NewMeter(exporter, time.Duration(cfg.Meter.Interval)*time.Second) // Create meter
+			shutdown := telemetry.NewMeter(exporter, time.Duration(cfg.Meter.Interval)*time.Second, cfg.Meter.ServiceName) // Create meter
 			// Cleanup on exit
 			defer func() {
 				if err = shutdown(ctx); err != nil {

--- a/pkg/telemetry/log.go
+++ b/pkg/telemetry/log.go
@@ -23,10 +23,10 @@ import (
 )
 
 // HandlerFactory - Create log handler according to given params
-func HandlerFactory(name, endpoint string, insecure bool, urlpath string, headers map[string]string, protocol string, level slog.Leveler) (slog.Handler, error) {
+func HandlerFactory(name, endpoint string, insecure bool, urlpath string, headers map[string]string, protocol string, level slog.Leveler, serviceName string) (slog.Handler, error) {
 	switch name {
 	case "otlp", "otlp-http", "otlp-grpc":
-		return NewOTLPHandler(endpoint, insecure, urlpath, headers, protocol, level.Level())
+		return NewOTLPHandler(endpoint, insecure, urlpath, headers, protocol, level.Level(), serviceName)
 	case "gcp":
 		return NewGCPHandler(headers, level)
 	default:
@@ -34,7 +34,7 @@ func HandlerFactory(name, endpoint string, insecure bool, urlpath string, header
 	}
 }
 
-func NewOTLPHandler(endpoint string, insecure bool, urlPath string, headers map[string]string, protocol string, level slog.Leveler) (slog.Handler, error) {
+func NewOTLPHandler(endpoint string, insecure bool, urlPath string, headers map[string]string, protocol string, level slog.Leveler, serviceName string) (slog.Handler, error) {
 	// Set up the OTLP exporter based on the protocol
 	exporter, err := logexporters.ExporterFactory("otlp", endpoint, insecure, urlPath, headers, protocol)
 	if err != nil {
@@ -42,7 +42,7 @@ func NewOTLPHandler(endpoint string, insecure bool, urlPath string, headers map[
 	}
 
 	// Initialize the OpenTelemetry handler with the exporter
-	lp := NewLog(exporter)
+	lp := NewLog(exporter, serviceName)
 	otelHandler := otelslog.NewOtelHandler(lp, &otelslog.HandlerOptions{
 		Level: level,
 	})
@@ -76,22 +76,22 @@ func NewGCPHandler(headers map[string]string, level slog.Leveler) (slog.Handler,
 }
 
 // NewLog - Creates new log
-func NewLog(exporter sdk.LogRecordExporter) *sdk.LoggerProvider {
+func NewLog(exporter sdk.LogRecordExporter, serviceName string) *sdk.LoggerProvider {
 	// Create a logger provider with the exporter and resource
 	lp := sdk.NewLoggerProvider(
 		sdk.WithBatcher(exporter),
-		sdk.WithResource(newResource()),
+		sdk.WithResource(newResource(serviceName)),
 	)
 
 	// Return the logger provider
 	return lp
 }
 
-func newResource() *resource.Resource {
+func newResource(serviceName string) *resource.Resource {
 	hostName, _ := os.Hostname()
 	return resource.NewWithAttributes(
 		semconv.SchemaURL,
-		semconv.ServiceNameKey.String("permify"),
+		semconv.ServiceNameKey.String(serviceName),
 		semconv.HostNameKey.String(hostName),
 		attribute.String("id", internal.Identifier),
 		attribute.String("project.id", internal.Identifier),

--- a/pkg/telemetry/log.go
+++ b/pkg/telemetry/log.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/Permify/sloggcp"
 	"github.com/agoda-com/opentelemetry-go/otelslog"
@@ -88,6 +89,9 @@ func NewLog(exporter sdk.LogRecordExporter, serviceName string) *sdk.LoggerProvi
 }
 
 func newResource(serviceName string) *resource.Resource {
+	if strings.TrimSpace(serviceName) == "" {
+		serviceName = "permify"
+	}
 	hostName, _ := os.Hostname()
 	return resource.NewWithAttributes(
 		semconv.SchemaURL,

--- a/pkg/telemetry/meter.go
+++ b/pkg/telemetry/meter.go
@@ -22,7 +22,7 @@ import (
 )
 
 // NewMeter - Creates new meter
-func NewMeter(exporter metric.Exporter, interval time.Duration) func(context.Context) error {
+func NewMeter(exporter metric.Exporter, interval time.Duration, serviceName string) func(context.Context) error {
 	hostName, err := os.Hostname()
 	if err != nil {
 		return func(context.Context) error { return nil }
@@ -35,7 +35,7 @@ func NewMeter(exporter metric.Exporter, interval time.Duration) func(context.Con
 		)),
 		metric.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("permify"),
+			semconv.ServiceNameKey.String(serviceName),
 			attribute.String("id", internal.Identifier),
 			attribute.String("project.id", internal.Identifier),
 			attribute.String("version", internal.Version),

--- a/pkg/telemetry/meter.go
+++ b/pkg/telemetry/meter.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -23,6 +24,9 @@ import (
 
 // NewMeter - Creates new meter
 func NewMeter(exporter metric.Exporter, interval time.Duration, serviceName string) func(context.Context) error {
+	if strings.TrimSpace(serviceName) == "" {
+		serviceName = "permify"
+	}
 	hostName, err := os.Hostname()
 	if err != nil {
 		return func(context.Context) error { return nil }

--- a/pkg/telemetry/tracer.go
+++ b/pkg/telemetry/tracer.go
@@ -16,7 +16,7 @@ import (
 )
 
 // NewTracer - Creates new tracer
-func NewTracer(exporter trace.SpanExporter) func(context.Context) error {
+func NewTracer(exporter trace.SpanExporter, serviceName string) func(context.Context) error {
 	hostName, err := os.Hostname()
 	if err != nil {
 		return func(context.Context) error { return nil }
@@ -26,7 +26,7 @@ func NewTracer(exporter trace.SpanExporter) func(context.Context) error {
 		trace.WithSpanProcessor(trace.NewBatchSpanProcessor(exporter)),
 		trace.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("permify"),
+			semconv.ServiceNameKey.String(serviceName),
 			attribute.String("id", internal.Identifier),
 			attribute.String("project.id", internal.Identifier),
 			attribute.String("version", internal.Version),

--- a/pkg/telemetry/tracer.go
+++ b/pkg/telemetry/tracer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"runtime"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -17,6 +18,9 @@ import (
 
 // NewTracer - Creates new tracer
 func NewTracer(exporter trace.SpanExporter, serviceName string) func(context.Context) error {
+	if strings.TrimSpace(serviceName) == "" {
+		serviceName = "permify"
+	}
 	hostName, err := os.Hostname()
 	if err != nil {
 		return func(context.Context) error { return nil }


### PR DESCRIPTION
## Summary

Closes #2877

Adds a `service_name` configuration option under `tracer`, `meter`, and `logger` sections, allowing users to override the service name reported by each exporter. Defaults to `"permify"` for backward compatibility.

### Configuration

```yaml
tracer:
  service_name: new-service-name

meter:
  service_name: new-service-name

logger:
  service_name: new-service-name
```

**CLI flags:** `--tracer-service-name`, `--meter-service-name`, `--log-service-name`
**Env vars:** `PERMIFY_TRACER_SERVICE_NAME`, `PERMIFY_METER_SERVICE_NAME`, `PERMIFY_LOG_SERVICE_NAME`

## Test plan

### Automated
- [x] `go build ./...` — clean build
- [x] `go test ./internal/config/...` — 9/9 pass (2 new tests for service name default + override)

### Manual testing

Tested locally using `grafana/otel-lgtm` all-in-one (Grafana + Loki + Tempo + Prometheus + OTel Collector):

```bash
docker run -d --name grafana-otel \
  -p 3000:3000 -p 4317:4317 -p 4318:4318 \
  grafana/otel-lgtm:latest

go run ./cmd/permify serve \
  --tracer-enabled=true --tracer-exporter=otlp --tracer-endpoint=localhost:4318 --tracer-insecure=true --tracer-service-name=my-custom-service \
  --meter-enabled=true --meter-exporter=otlp --meter-endpoint=localhost:4318 --meter-insecure=true --meter-interval=5 --meter-service-name=my-custom-service \
  --log-enabled=true --log-exporter=otlp --log-endpoint=localhost:4318 --log-insecure=true --log-level=info --log-service-name=my-custom-service
```

Then open http://localhost:3000 and verify:

- [x] **Logs** (Loki): query `{service_name="my-custom-service"}` — logs appear with correct service name
- [x] **Metrics** (Prometheus): query `{job="my-custom-service"}` — runtime/host metrics appear
- [x] **Traces** (Jaeger / Grafana): search by service `my-custom-service` — traces appear

**Screenshot — Logs in Grafana showing `my-custom-service`:**

<img width="1433" height="308" alt="logs" src="https://github.com/user-attachments/assets/7fc4102e-cb3d-455e-9361-ffc17a5d3e87" />

**Screenshot — Metrics showing `my-custom-service`:**
<img width="1693" height="746" alt="metrics" src="https://github.com/user-attachments/assets/0ff53ac2-2406-4581-84af-3bf4fe90c7b0" />

**Screenshot — Traces in Grafana / Jaeger showing `my-custom-service`:**
<img width="1851" height="899" alt="image" src="https://github.com/user-attachments/assets/2f2059b1-2c99-41c8-a730-95eac7479474" />

<img width="1714" height="856" alt="traces" src="https://github.com/user-attachments/assets/3655eab5-31df-41b8-868f-9ff3c1c9eff4" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable service-name for logging, tracing, and metering (default: "permify"); configurable via config files, environment variables, or CLI flags.

* **Documentation**
  * Updated configuration guide and example config to document the new service-name options and corresponding environment variables.

* **Tests**
  * Added tests to verify service-name defaults and loading from configuration files.

* **Chores**
  * Config inspection now displays configured service-name for each telemetry component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->