### PR TITLE
docs: update otlp.mdx

### DIFF
--- a/docs/integrations/metrics/otlp.mdx
+++ b/docs/integrations/metrics/otlp.mdx
@@ -44,7 +44,7 @@ Ensure that your configuration file is loaded when starting Permify, and confirm
 
 ### Step 4: View Traces in Your Chosen UI
 
-Once the setup is complete and your application begins sending traces, you can view the trace data in a backend such as [Jaeger](https://www.jaegertracing.io), [Zipkin](https://zipkin.io), [Dash0](https://www.dash0.com) or any system supported by the OpenTelemetry Collector.
+Once the setup is complete and your application begins sending traces, you can view the trace data in a backend such as [Jaeger](https://www.jaegertracing.io), [Zipkin](https://zipkin.io), [Dash0](https://www.dash0.com), [Middleware](https://middleware.io/) or any system supported by the OpenTelemetry Collector.
 
 ### Meter Configuration
 


### PR DESCRIPTION
docs: added Middleware in OpenTelemetry file for providing more options to view traces pointer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OTLP integration guide to include Middleware as an additional supported tracing backend example alongside Jaeger, Zipkin, and Dash0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->