### PR TITLE
refactor: refine schema files for scenario-specific relationships

### DIFF
--- a/assets/example-shapes/banking-system.yaml
+++ b/assets/example-shapes/banking-system.yaml
@@ -5,7 +5,7 @@ schema: |-
 
         // Defines a relation where an account has an owner of type 'user'.
         relation owner @user
-        
+
         // Attribute to store the balance information of the account.
         attribute balance integer
 
@@ -36,8 +36,6 @@ scenarios:
       - entity: "account:1"
         subject: "user:andrew"
         context:
-          tuples: []
-          attributes: []
           data:
             amount: 3000
         assertions:
@@ -48,9 +46,34 @@ scenarios:
       - entity: "account:1"
         subject: "user:steven"
         context:
-          tuples: []
-          attributes: []
           data:
             amount: 3000
+        assertions:
+          withdraw: false
+
+  # Scenario-scoped relationships and attributes stay in the scenario and are
+  # injected as contextual tuples and attributes into every check/filter below.
+  # Useful when a scenario needs its own fixture state without persisting it
+  # globally or repeating it per-check.
+  - name: "Joint Account Withdrawal Test"
+    description: "Tests a joint account where both 'andrew' and 'kate' are owners and the balance covers the requested amount."
+    relationships:
+      - account:3#owner@user:andrew
+      - account:3#owner@user:kate
+    attributes:
+      - account:3$balance|integer:2000
+    checks:
+      - entity: "account:3"
+        subject: "user:kate"
+        context:
+          data:
+            amount: 1500
+        assertions:
+          withdraw: true
+      - entity: "account:3"
+        subject: "user:steven"
+        context:
+          data:
+            amount: 1500
         assertions:
           withdraw: false

--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -235,7 +235,7 @@ func validate() func(cmd *cobra.Command, args []string) error {
 
 			// Convert scenario-scoped relationships and attributes once so they can be
 			// merged into every check/filter context in this scenario.
-			scenarioTuples, scenarioAttrs, scErrs := scenarioContext(ctx, dev, version, scenario)
+			scenarioTuples, scenarioAttrs, scErrs := dev.ScenarioContext(ctx, version, scenario)
 			for _, e := range scErrs {
 				list.Add(e)
 				color.Danger.Printf("  fail: %s\n", validationError(e))
@@ -593,52 +593,3 @@ func Context(fileContext file.Context) (cont *base.Context, err error) {
 	return cont, nil
 }
 
-// scenarioContext converts a scenario's relationships and attributes into base
-// tuples and attributes, validated against the schema at the given version.
-// Any per-item validation or parse errors are returned as strings so the caller
-// can surface them through the same reporting path as other scenario errors.
-func scenarioContext(ctx context.Context, dev *development.Development, version string, scenario file.Scenario) (tuples []*base.Tuple, attrs []*base.Attribute, errs []string) {
-	for _, t := range scenario.Relationships {
-		tup, err := tuple.Tuple(t)
-		if err != nil {
-			errs = append(errs, err.Error())
-			continue
-		}
-
-		definition, _, err := dev.Container.SR.ReadEntityDefinition(ctx, "t1", tup.GetEntity().GetType(), version)
-		if err != nil {
-			errs = append(errs, err.Error())
-			continue
-		}
-
-		if err := serverValidation.ValidateTuple(definition, tup); err != nil {
-			errs = append(errs, err.Error())
-			continue
-		}
-
-		tuples = append(tuples, tup)
-	}
-
-	for _, a := range scenario.Attributes {
-		attr, err := attribute.Attribute(a)
-		if err != nil {
-			errs = append(errs, err.Error())
-			continue
-		}
-
-		definition, _, err := dev.Container.SR.ReadEntityDefinition(ctx, "t1", attr.GetEntity().GetType(), version)
-		if err != nil {
-			errs = append(errs, err.Error())
-			continue
-		}
-
-		if err := serverValidation.ValidateAttribute(definition, attr); err != nil {
-			errs = append(errs, err.Error())
-			continue
-		}
-
-		attrs = append(attrs, attr)
-	}
-
-	return
-}

--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -240,6 +240,12 @@ func validate() func(cmd *cobra.Command, args []string) error {
 				list.Add(e)
 				color.Danger.Printf("  fail: %s\n", validationError(e))
 			}
+			// If the scenario's own fixtures failed to convert/validate, skip its
+			// checks and filters so we don't cascade into spurious assertion
+			// failures driven by the missing context.
+			if len(scErrs) > 0 {
+				continue
+			}
 
 			// Start log output for checks
 			color.Notice.Println("  checks:")
@@ -592,4 +598,3 @@ func Context(fileContext file.Context) (cont *base.Context, err error) {
 	// If everything goes well, return the context and a nil error.
 	return cont, nil
 }
-

--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -233,6 +233,14 @@ func validate() func(cmd *cobra.Command, args []string) error {
 		for sn, scenario := range s.Scenarios {
 			color.Notice.Printf("%v.scenario: %s - %s\n", sn+1, scenario.Name, scenario.Description)
 
+			// Convert scenario-scoped relationships and attributes once so they can be
+			// merged into every check/filter context in this scenario.
+			scenarioTuples, scenarioAttrs, scErrs := scenarioContext(ctx, dev, version, scenario)
+			for _, e := range scErrs {
+				list.Add(e)
+				color.Danger.Printf("  fail: %s\n", validationError(e))
+			}
+
 			// Start log output for checks
 			color.Notice.Println("  checks:")
 
@@ -267,6 +275,8 @@ func validate() func(cmd *cobra.Command, args []string) error {
 					color.Danger.Printf("    fail: %s\n", validationError(err.Error()))
 					continue
 				}
+				cont.Tuples = append(cont.Tuples, scenarioTuples...)
+				cont.Attributes = append(cont.Attributes, scenarioAttrs...)
 
 				// Iterate over all assertions in the check
 				for permission, expected := range check.Assertions {
@@ -352,6 +362,8 @@ func validate() func(cmd *cobra.Command, args []string) error {
 					color.Danger.Printf("    fail: %s\n", validationError(err.Error()))
 					continue
 				}
+				cont.Tuples = append(cont.Tuples, scenarioTuples...)
+				cont.Attributes = append(cont.Attributes, scenarioAttrs...)
 
 				// Iterate over each assertion in the filter.
 				for permission, expected := range filter.Assertions {
@@ -424,6 +436,8 @@ func validate() func(cmd *cobra.Command, args []string) error {
 					color.Danger.Printf("    fail: %s\n", validationError(err.Error()))
 					continue
 				}
+				cont.Tuples = append(cont.Tuples, scenarioTuples...)
+				cont.Attributes = append(cont.Attributes, scenarioAttrs...)
 
 				// Iterate over each assertion in the filter.
 				for permission, expected := range filter.Assertions {
@@ -577,4 +591,54 @@ func Context(fileContext file.Context) (cont *base.Context, err error) {
 
 	// If everything goes well, return the context and a nil error.
 	return cont, nil
+}
+
+// scenarioContext converts a scenario's relationships and attributes into base
+// tuples and attributes, validated against the schema at the given version.
+// Any per-item validation or parse errors are returned as strings so the caller
+// can surface them through the same reporting path as other scenario errors.
+func scenarioContext(ctx context.Context, dev *development.Development, version string, scenario file.Scenario) (tuples []*base.Tuple, attrs []*base.Attribute, errs []string) {
+	for _, t := range scenario.Relationships {
+		tup, err := tuple.Tuple(t)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		definition, _, err := dev.Container.SR.ReadEntityDefinition(ctx, "t1", tup.GetEntity().GetType(), version)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		if err := serverValidation.ValidateTuple(definition, tup); err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		tuples = append(tuples, tup)
+	}
+
+	for _, a := range scenario.Attributes {
+		attr, err := attribute.Attribute(a)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		definition, _, err := dev.Container.SR.ReadEntityDefinition(ctx, "t1", attr.GetEntity().GetType(), version)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		if err := serverValidation.ValidateAttribute(definition, attr); err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		attrs = append(attrs, attr)
+	}
+
+	return
 }

--- a/pkg/development/coverage/coverage.go
+++ b/pkg/development/coverage/coverage.go
@@ -177,11 +177,19 @@ func calculateEntityCoverages(refs []SchemaCoverage, shape file.Shape) []EntityC
 func calculateEntityCoverage(ref SchemaCoverage, shape file.Shape) EntityCoverageInfo {
 	entityCoverageInfo := newEntityCoverageInfo(ref.EntityName)
 
+	// Scenario-scoped relationships and attributes also count toward coverage.
+	allRelationships := append([]string{}, shape.Relationships...)
+	allAttributes := append([]string{}, shape.Attributes...)
+	for _, sc := range shape.Scenarios {
+		allRelationships = append(allRelationships, sc.Relationships...)
+		allAttributes = append(allAttributes, sc.Attributes...)
+	}
+
 	// Calculate relationships coverage
 	entityCoverageInfo.UncoveredRelationships = findUncoveredRelationships(
 		ref.EntityName,
 		ref.Relationships,
-		shape.Relationships,
+		allRelationships,
 	)
 	entityCoverageInfo.CoverageRelationshipsPercent = calculateCoveragePercent(
 		ref.Relationships,
@@ -192,7 +200,7 @@ func calculateEntityCoverage(ref SchemaCoverage, shape file.Shape) EntityCoverag
 	entityCoverageInfo.UncoveredAttributes = findUncoveredAttributes(
 		ref.EntityName,
 		ref.Attributes,
-		shape.Attributes,
+		allAttributes,
 	)
 	entityCoverageInfo.CoverageAttributesPercent = calculateCoveragePercent(
 		ref.Attributes,

--- a/pkg/development/development.go
+++ b/pkg/development/development.go
@@ -292,6 +292,12 @@ func (c *Development) RunWithShape(ctx context.Context, shape *file.Shape) (erro
 				Message: e,
 			})
 		}
+		// If the scenario's own fixtures failed to convert/validate, skip its
+		// checks and filters so we don't cascade into spurious assertion
+		// failures driven by the missing context.
+		if len(scErrs) > 0 {
+			continue
+		}
 
 		// Each Check in the current scenario is processed
 		for _, check := range scenario.Checks {

--- a/pkg/development/development.go
+++ b/pkg/development/development.go
@@ -284,7 +284,7 @@ func (c *Development) RunWithShape(ctx context.Context, shape *file.Shape) (erro
 	for i, scenario := range shape.Scenarios {
 		// Convert scenario-scoped relationships and attributes once so they can be
 		// merged into every check/filter context in this scenario.
-		scenarioTuples, scenarioAttrs, scErrs := c.scenarioContext(ctx, version, scenario)
+		scenarioTuples, scenarioAttrs, scErrs := c.ScenarioContext(ctx, version, scenario)
 		for _, e := range scErrs {
 			errors = append(errors, Error{
 				Type:    "scenarios",
@@ -586,11 +586,14 @@ func Context(fileContext file.Context) (cont *v1.Context, err error) {
 	return cont, nil
 }
 
-// scenarioContext converts a scenario's relationships and attributes into base
+// ScenarioContext converts a scenario's relationships and attributes into base
 // tuples and attributes, validated against the schema at the given version.
 // Any per-item validation or parse errors are collected and returned as strings
 // so the caller can report them under the "scenarios" error type.
-func (c *Development) scenarioContext(ctx context.Context, version string, scenario file.Scenario) (tuples []*v1.Tuple, attrs []*v1.Attribute, errs []string) {
+//
+// Exported so that callers outside this package (e.g. the CLI validator) can
+// reuse the same conversion/validation logic.
+func (c *Development) ScenarioContext(ctx context.Context, version string, scenario file.Scenario) (tuples []*v1.Tuple, attrs []*v1.Attribute, errs []string) {
 	for _, t := range scenario.Relationships {
 		tup, err := tuple.Tuple(t)
 		if err != nil {

--- a/pkg/development/development.go
+++ b/pkg/development/development.go
@@ -282,6 +282,17 @@ func (c *Development) RunWithShape(ctx context.Context, shape *file.Shape) (erro
 
 	// Each item in the Scenarios slice is processed individually
 	for i, scenario := range shape.Scenarios {
+		// Convert scenario-scoped relationships and attributes once so they can be
+		// merged into every check/filter context in this scenario.
+		scenarioTuples, scenarioAttrs, scErrs := c.scenarioContext(ctx, version, scenario)
+		for _, e := range scErrs {
+			errors = append(errors, Error{
+				Type:    "scenarios",
+				Key:     i,
+				Message: e,
+			})
+		}
+
 		// Each Check in the current scenario is processed
 		for _, check := range scenario.Checks {
 			entity, err := tuple.E(check.Entity)
@@ -313,6 +324,8 @@ func (c *Development) RunWithShape(ctx context.Context, shape *file.Shape) (erro
 				})
 				continue
 			}
+			cont.Tuples = append(cont.Tuples, scenarioTuples...)
+			cont.Attributes = append(cont.Attributes, scenarioAttrs...)
 
 			subject := &v1.Subject{
 				Type:     ear.GetEntity().GetType(),
@@ -399,6 +412,8 @@ func (c *Development) RunWithShape(ctx context.Context, shape *file.Shape) (erro
 				})
 				continue
 			}
+			cont.Tuples = append(cont.Tuples, scenarioTuples...)
+			cont.Attributes = append(cont.Attributes, scenarioAttrs...)
 
 			subject := &v1.Subject{
 				Type:     ear.GetEntity().GetType(),
@@ -462,6 +477,8 @@ func (c *Development) RunWithShape(ctx context.Context, shape *file.Shape) (erro
 				})
 				continue
 			}
+			cont.Tuples = append(cont.Tuples, scenarioTuples...)
+			cont.Attributes = append(cont.Attributes, scenarioAttrs...)
 
 			var entity *v1.Entity
 			entity, err = tuple.E(filter.Entity)
@@ -567,6 +584,56 @@ func Context(fileContext file.Context) (cont *v1.Context, err error) {
 
 	// If everything goes well, return the context and a nil error.
 	return cont, nil
+}
+
+// scenarioContext converts a scenario's relationships and attributes into base
+// tuples and attributes, validated against the schema at the given version.
+// Any per-item validation or parse errors are collected and returned as strings
+// so the caller can report them under the "scenarios" error type.
+func (c *Development) scenarioContext(ctx context.Context, version string, scenario file.Scenario) (tuples []*v1.Tuple, attrs []*v1.Attribute, errs []string) {
+	for _, t := range scenario.Relationships {
+		tup, err := tuple.Tuple(t)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		definition, _, err := c.Container.SR.ReadEntityDefinition(ctx, "t1", tup.GetEntity().GetType(), version)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		if err := validation.ValidateTuple(definition, tup); err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		tuples = append(tuples, tup)
+	}
+
+	for _, a := range scenario.Attributes {
+		attr, err := attribute.Attribute(a)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		definition, _, err := c.Container.SR.ReadEntityDefinition(ctx, "t1", attr.GetEntity().GetType(), version)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		if err := validation.ValidateAttribute(definition, attr); err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		attrs = append(attrs, attr)
+	}
+
+	return
 }
 
 // isSameArray - check if two arrays are the same

--- a/pkg/development/development_test.go
+++ b/pkg/development/development_test.go
@@ -1,0 +1,123 @@
+package development
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Permify/permify/pkg/development/file"
+)
+
+// TestScenarioScopedRelationshipsAndAttributes exercises the Scenario.Relationships
+// and Scenario.Attributes fields end-to-end through RunWithShape. The scenario's
+// relationships and attributes must be treated as contextual data: they are
+// scoped to the scenario's checks and must not leak into later scenarios.
+func TestScenarioScopedRelationshipsAndAttributes(t *testing.T) {
+	schema := `
+entity user {}
+
+entity account {
+    relation owner @user
+    attribute balance integer
+
+    permission withdraw = check_balance(balance) and owner
+}
+
+rule check_balance(balance integer) {
+    (balance >= context.data.amount) && (context.data.amount <= 5000)
+}
+`
+
+	shape := &file.Shape{
+		Schema:        schema,
+		Relationships: []string{},
+		Attributes:    []string{},
+		Scenarios: []file.Scenario{
+			{
+				Name: "scenario-scoped owner can withdraw",
+				Relationships: []string{
+					"account:1#owner@user:andrew",
+				},
+				Attributes: []string{
+					"account:1$balance|integer:2000",
+				},
+				Checks: []file.Check{
+					{
+						Entity:  "account:1",
+						Subject: "user:andrew",
+						Context: file.Context{
+							Data: map[string]interface{}{"amount": 1500},
+						},
+						Assertions: map[string]bool{"withdraw": true},
+					},
+				},
+			},
+			{
+				Name: "scenario-scoped data does not leak across scenarios",
+				// No scenario-scoped fixtures here. user:andrew should no longer be
+				// an owner of account:1 and the balance attribute should not apply.
+				Checks: []file.Check{
+					{
+						Entity:  "account:1",
+						Subject: "user:andrew",
+						Context: file.Context{
+							Data: map[string]interface{}{"amount": 1500},
+						},
+						Assertions: map[string]bool{"withdraw": false},
+					},
+				},
+			},
+		},
+	}
+
+	dev := NewContainer()
+	errs := dev.RunWithShape(context.Background(), shape)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %+v", errs)
+	}
+}
+
+// TestScenarioRelationshipsReportInvalidTuple verifies that a malformed
+// scenario-scoped relationship is surfaced as a scenarios-scoped error rather
+// than crashing the run.
+func TestScenarioRelationshipsReportInvalidTuple(t *testing.T) {
+	shape := &file.Shape{
+		Schema: `
+entity user {}
+entity account {
+    relation owner @user
+    permission view = owner
+}
+`,
+		Scenarios: []file.Scenario{
+			{
+				Name: "bad tuple",
+				Relationships: []string{
+					"not-a-valid-tuple",
+				},
+				Checks: []file.Check{
+					{
+						Entity:     "account:1",
+						Subject:    "user:andrew",
+						Assertions: map[string]bool{"view": false},
+					},
+				},
+			},
+		},
+	}
+
+	dev := NewContainer()
+	errs := dev.RunWithShape(context.Background(), shape)
+	if len(errs) == 0 {
+		t.Fatalf("expected at least one error for invalid scenario relationship")
+	}
+	found := false
+	for _, e := range errs {
+		if e.Type == "scenarios" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected an error with Type=scenarios, got %+v", errs)
+	}
+}

--- a/pkg/development/development_test.go
+++ b/pkg/development/development_test.go
@@ -76,6 +76,67 @@ rule check_balance(balance integer) {
 	}
 }
 
+// TestScenarioScopedFixturesApplyToFilters verifies that scenario-scoped
+// relationships and attributes are merged into the context of both entity
+// filters and subject filters, not just checks.
+func TestScenarioScopedFixturesApplyToFilters(t *testing.T) {
+	schema := `
+entity user {}
+
+entity account {
+    relation owner @user
+    attribute active boolean
+
+    permission view = is_active(active) and owner
+}
+
+rule is_active(active boolean) {
+    active == true
+}
+`
+
+	shape := &file.Shape{
+		Schema: schema,
+		Scenarios: []file.Scenario{
+			{
+				Name: "filters see scenario-scoped fixtures",
+				Relationships: []string{
+					"account:1#owner@user:andrew",
+					"account:2#owner@user:andrew",
+				},
+				Attributes: []string{
+					"account:1$active|boolean:true",
+					"account:2$active|boolean:true",
+				},
+				EntityFilters: []file.EntityFilter{
+					{
+						EntityType: "account",
+						Subject:    "user:andrew",
+						Assertions: map[string][]string{
+							"view": {"1", "2"},
+						},
+					},
+				},
+				SubjectFilters: []file.SubjectFilter{
+					{
+						SubjectReference: "user",
+						Entity:           "account:1",
+						Assertions: map[string][]string{
+							"view": {"andrew"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dev := NewContainer()
+	errs := dev.RunWithShape(context.Background(), shape)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %+v", errs)
+	}
+}
+
 // TestScenarioRelationshipsReportInvalidTuple verifies that a malformed
 // scenario-scoped relationship is surfaced as a scenarios-scoped error rather
 // than crashing the run.
@@ -109,6 +170,56 @@ entity account {
 	errs := dev.RunWithShape(context.Background(), shape)
 	if len(errs) == 0 {
 		t.Fatalf("expected at least one error for invalid scenario relationship")
+	}
+	found := false
+	for _, e := range errs {
+		if e.Type == "scenarios" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected an error with Type=scenarios, got %+v", errs)
+	}
+}
+
+// TestScenarioAttributesReportInvalidAttribute is the attribute-path mirror of
+// TestScenarioRelationshipsReportInvalidTuple: a malformed scenario-scoped
+// attribute must be reported as a scenarios error instead of crashing.
+func TestScenarioAttributesReportInvalidAttribute(t *testing.T) {
+	shape := &file.Shape{
+		Schema: `
+entity user {}
+entity account {
+    attribute active boolean
+    permission view = is_active(active)
+}
+
+rule is_active(active boolean) {
+    active == true
+}
+`,
+		Scenarios: []file.Scenario{
+			{
+				Name: "bad attribute",
+				Attributes: []string{
+					"not-a-valid-attribute",
+				},
+				Checks: []file.Check{
+					{
+						Entity:     "account:1",
+						Subject:    "user:andrew",
+						Assertions: map[string]bool{"view": false},
+					},
+				},
+			},
+		},
+	}
+
+	dev := NewContainer()
+	errs := dev.RunWithShape(context.Background(), shape)
+	if len(errs) == 0 {
+		t.Fatalf("expected at least one error for invalid scenario attribute")
 	}
 	found := false
 	for _, e := range errs {

--- a/pkg/development/development_test.go
+++ b/pkg/development/development_test.go
@@ -2,6 +2,7 @@ package development
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/Permify/permify/pkg/development/file"
@@ -63,6 +64,33 @@ rule check_balance(balance integer) {
 							Data: map[string]interface{}{"amount": 1500},
 						},
 						Assertions: map[string]bool{"withdraw": false},
+					},
+				},
+				// Explicit negative lookups: if the previous scenario's owner tuple
+				// leaked, account:1 would resolve for user:andrew and user:andrew
+				// would resolve as a viewer of account:1. Both must be empty.
+				EntityFilters: []file.EntityFilter{
+					{
+						EntityType: "account",
+						Subject:    "user:andrew",
+						Context: file.Context{
+							Data: map[string]interface{}{"amount": 1500},
+						},
+						Assertions: map[string][]string{
+							"withdraw": {},
+						},
+					},
+				},
+				SubjectFilters: []file.SubjectFilter{
+					{
+						SubjectReference: "user",
+						Entity:           "account:1",
+						Context: file.Context{
+							Data: map[string]interface{}{"amount": 1500},
+						},
+						Assertions: map[string][]string{
+							"withdraw": {},
+						},
 					},
 				},
 			},
@@ -173,13 +201,13 @@ entity account {
 	}
 	found := false
 	for _, e := range errs {
-		if e.Type == "scenarios" {
+		if e.Type == "scenarios" && e.Key == 0 && strings.Contains(e.Message, "invalid tuple") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected an error with Type=scenarios, got %+v", errs)
+		t.Fatalf("expected a scenarios error at key 0 from the tuple parser, got %+v", errs)
 	}
 }
 
@@ -223,12 +251,12 @@ rule is_active(active boolean) {
 	}
 	found := false
 	for _, e := range errs {
-		if e.Type == "scenarios" {
+		if e.Type == "scenarios" && e.Key == 0 && strings.Contains(e.Message, "invalid attribute") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected an error with Type=scenarios, got %+v", errs)
+		t.Fatalf("expected a scenarios error at key 0 from the attribute parser, got %+v", errs)
 	}
 }

--- a/pkg/development/file/shape.go
+++ b/pkg/development/file/shape.go
@@ -25,6 +25,17 @@ type Scenario struct {
 	// Description is a string that provides a brief explanation of the scenario.
 	Description string `yaml:"description"`
 
+	// Relationships is a slice of strings that represent relationships scoped to this
+	// scenario. They are merged as contextual tuples into every Check, EntityFilter,
+	// and SubjectFilter inside the scenario and are not persisted beyond it.
+	Relationships []string `yaml:"relationships"`
+
+	// Attributes is a slice of strings that represent attributes scoped to this
+	// scenario. They are merged as contextual attributes into every Check,
+	// EntityFilter, and SubjectFilter inside the scenario and are not persisted
+	// beyond it.
+	Attributes []string `yaml:"attributes"`
+
 	// Checks is a slice of Check structs that represent the authorization checks to be performed.
 	Checks []Check `yaml:"checks"`
 


### PR DESCRIPTION
/claim Permify/permify#838

## Summary

Adds `relationships` and `attributes` fields to `file.Scenario` so a validation shape can declare fixture data that is scoped to a single scenario instead of repeating it per-check or forcing it into the globally-persisted pools.

**Semantics.** Scenario-level relationships and attributes are injected as contextual tuples and attributes into every `check`, `entity_filter`, and `subject_filter` inside that scenario. They are not persisted to the in-memory store. This matches Permify's existing "contextual tuples/attributes" concept (`pkg/pb/base/v1 Context`) and keeps scenarios isolated from one another — a relationship declared under scenario A does not leak into scenario B.

**Mental model**
- Top-level `relationships` / `attributes` — persisted globally, shared across all scenarios.
- `scenarios[].relationships` / `scenarios[].attributes` — contextual, scoped to that scenario's checks and filters.
- `scenarios[].checks[].context.tuples` / `...attributes` — contextual, scoped to a single check (unchanged).

### Changes

1. `pkg/development/file/shape.go` — add `Relationships []string` and `Attributes []string` to `Scenario` (both omit-empty via zero-value slices, so existing YAMLs are unaffected).
2. `pkg/cmd/validate.go` — before iterating a scenario's checks/filters, convert and schema-validate the scenario's tuples/attributes once via a new `scenarioContext` helper, then append them to the `base.Context` built for each check / entity filter / subject filter. Per-item parse or validation errors are reported through the existing scenario error path.
3. `pkg/development/development.go` — same treatment for the development container path (playground, dev server). Errors surface under `Type: "scenarios"` with the scenario index.
4. `pkg/development/coverage/coverage.go` — scenario-scoped relationships and attributes now count toward coverage so the coverage report does not under-count when a relationship is only declared inside a scenario.
5. `pkg/development/development_test.go` (new) — two tests: `TestScenarioScopedRelationshipsAndAttributes` verifies the field works end-to-end and that scenario-scoped data does not leak across scenarios; `TestScenarioRelationshipsReportInvalidTuple` verifies that malformed scenario-scoped data is surfaced as a `scenarios` error instead of crashing the run.
6. `assets/example-shapes/banking-system.yaml` — adds a third scenario ("Joint Account Withdrawal Test") that uses the new fields to set up an `account:3` with two owners and a scenario-local balance, without polluting the global fixture for accounts 1 and 2.

### Validation

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean.
- `go test ./pkg/development/...` — pass (new tests included).
- `go run ./cmd/permify validate assets/example-shapes/banking-system.yaml` — `SUCCESS`, all three scenarios (including the new one using `scenarios[].relationships` and `scenarios[].attributes`) return the expected check results.

A short recording of the validator run and unit tests passing is attached in the session thread.

## Review & Testing Checklist for Human

Risk: yellow (data-model addition to `file.Shape`, consumed by the CLI validator, the development container, and coverage).

- [ ] Confirm the semantics of "contextual, not persisted" is the right choice versus persisting and isolating per scenario — I went with contextual because it avoids cross-scenario state leakage without requiring per-scenario DB snapshots, and it mirrors `base.Context` on real check requests.
- [ ] Verify the coverage change: scenario-scoped relationships/attributes are now counted in `calculateEntityCoverage`. If scenario-scoped fixtures should *not* contribute to coverage (because they're test-local), revert that specific hunk.
- [ ] Run the Playground against a shape that uses the new fields to confirm the dev container path behaves the same as the CLI.
- [ ] Existing YAMLs in `assets/example-shapes/` were left untouched except for `banking-system.yaml`. Sanity-check that this is the right place to demonstrate the pattern, or move the demo to a new example file.

Test plan for a reviewer:
1. `go test ./pkg/development/...` on this branch — both new tests should pass.
2. `go run ./cmd/permify validate assets/example-shapes/banking-system.yaml` — should print three scenarios, all `SUCCESS`.
3. In the new scenario, temporarily delete one `account:3#owner@user:kate` tuple and re-run validate — the check for `user:kate withdraw account:3` should then fail, proving the scenario-scoped relationships are what's driving the allow.

### Notes

No parser or DSL changes. No breaking changes to existing YAMLs — the two new `Scenario` fields default to empty slices and are ignored when absent. The existing `Context` field on `Check` / `EntityFilter` / `SubjectFilter` is unchanged; scenario-scoped data is appended to it, not replaced.



###  Demo
**Short terminal recording of the changes in action:**
- Shows the updated `banking-system.yaml` scenario using `scenarios[].relationships` and `scenarios[].attributes`.
- Runs `go run ./cmd/permify validate` (all three scenarios **SUCCESS**).
- Verifies the two new unit tests passing.


https://github.com/user-attachments/assets/53d914ba-4b89-42d7-a25c-f99bdbcdbc27




