### PR TITLE
fix: stop leaking postgres testcontainers in coverage runs

### DIFF
--- a/internal/storage/postgres/bundle_reader_test.go
+++ b/internal/storage/postgres/bundle_reader_test.go
@@ -8,14 +8,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/Permify/permify/internal/storage"
-	"github.com/Permify/permify/pkg/database"
-	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 	base "github.com/Permify/permify/pkg/pb/base/v1"
 	"github.com/Permify/permify/pkg/testinstance"
 )
 
 var _ = Describe("BundleReader", func() {
-	var db database.Database
+	var db *testinstance.PostgresInstance
 	var bundleWriter *BundleWriter
 	var bundleReader *BundleReader
 
@@ -27,8 +25,8 @@ var _ = Describe("BundleReader", func() {
 		}
 
 		db = testinstance.PostgresDB(version)
-		bundleWriter = NewBundleWriter(db.(*PQDatabase.Postgres))
-		bundleReader = NewBundleReader(db.(*PQDatabase.Postgres))
+		bundleWriter = NewBundleWriter(db.Postgres)
+		bundleReader = NewBundleReader(db.Postgres)
 	})
 
 	AfterEach(func() {
@@ -117,7 +115,7 @@ var _ = Describe("BundleReader", func() {
 			ctx := context.Background()
 
 			// First, write a bundle with valid JSON that doesn't match the protobuf structure
-			postgresDB := db.(*PQDatabase.Postgres)
+			postgresDB := db.Postgres
 
 			// Insert valid JSON that doesn't match the DataBundle structure
 			invalidJSON := `{"invalid_field": "invalid_value", "another_field": 123}`

--- a/internal/storage/postgres/bundle_writer_test.go
+++ b/internal/storage/postgres/bundle_writer_test.go
@@ -8,14 +8,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/Permify/permify/internal/storage"
-	"github.com/Permify/permify/pkg/database"
-	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 	base "github.com/Permify/permify/pkg/pb/base/v1"
 	"github.com/Permify/permify/pkg/testinstance"
 )
 
 var _ = Describe("BundleWriter", func() {
-	var db database.Database
+	var db *testinstance.PostgresInstance
 	var bundleWriter *BundleWriter
 	var bundleReader *BundleReader
 
@@ -27,8 +25,8 @@ var _ = Describe("BundleWriter", func() {
 		}
 
 		db = testinstance.PostgresDB(version)
-		bundleWriter = NewBundleWriter(db.(*PQDatabase.Postgres))
-		bundleReader = NewBundleReader(db.(*PQDatabase.Postgres))
+		bundleWriter = NewBundleWriter(db.Postgres)
+		bundleReader = NewBundleReader(db.Postgres)
 	})
 
 	AfterEach(func() {

--- a/internal/storage/postgres/data_reader_test.go
+++ b/internal/storage/postgres/data_reader_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Permify/permify/pkg/attribute"
 	"github.com/Permify/permify/pkg/database"
-	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 	base "github.com/Permify/permify/pkg/pb/base/v1"
 	"github.com/Permify/permify/pkg/testinstance"
 	"github.com/Permify/permify/pkg/token"
@@ -18,7 +17,7 @@ import (
 )
 
 var _ = Describe("DataReader", func() {
-	var db database.Database
+	var db *testinstance.PostgresInstance
 	var dataWriter *DataWriter
 	var dataReader *DataReader
 
@@ -30,8 +29,8 @@ var _ = Describe("DataReader", func() {
 		}
 
 		db = testinstance.PostgresDB(version)
-		dataWriter = NewDataWriter(db.(*PQDatabase.Postgres))
-		dataReader = NewDataReader(db.(*PQDatabase.Postgres))
+		dataWriter = NewDataWriter(db.Postgres)
+		dataReader = NewDataReader(db.Postgres)
 	})
 
 	AfterEach(func() {
@@ -499,8 +498,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger errors
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -533,8 +532,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -552,8 +551,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger execution error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -572,8 +571,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -595,8 +594,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger errors
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -641,8 +640,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -660,8 +659,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger execution error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -680,8 +679,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -703,8 +702,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger errors
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -737,8 +736,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -756,8 +755,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger execution error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -776,8 +775,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -799,8 +798,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger errors
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -845,8 +844,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -864,8 +863,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger execution error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -884,8 +883,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -922,8 +921,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -941,8 +940,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger execution error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -961,8 +960,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -984,8 +983,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)
@@ -1011,8 +1010,8 @@ var _ = Describe("DataReader", func() {
 				ctx := context.Background()
 
 				// Create a dataReader with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewDataReader(closedDB)

--- a/internal/storage/postgres/data_writer_test.go
+++ b/internal/storage/postgres/data_writer_test.go
@@ -11,14 +11,13 @@ import (
 	"github.com/Permify/permify/internal/storage"
 	"github.com/Permify/permify/pkg/attribute"
 	"github.com/Permify/permify/pkg/database"
-	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 	base "github.com/Permify/permify/pkg/pb/base/v1"
 	"github.com/Permify/permify/pkg/testinstance"
 	"github.com/Permify/permify/pkg/tuple"
 )
 
 var _ = Describe("DataWriter", func() {
-	var db database.Database
+	var db *testinstance.PostgresInstance
 	var dataWriter *DataWriter
 	var dataReader *DataReader
 	var bundleWriter *BundleWriter
@@ -32,10 +31,10 @@ var _ = Describe("DataWriter", func() {
 		}
 
 		db = testinstance.PostgresDB(version)
-		dataWriter = NewDataWriter(db.(*PQDatabase.Postgres))
-		dataReader = NewDataReader(db.(*PQDatabase.Postgres))
-		bundleWriter = NewBundleWriter(db.(*PQDatabase.Postgres))
-		bundleReader = NewBundleReader(db.(*PQDatabase.Postgres))
+		dataWriter = NewDataWriter(db.Postgres)
+		dataReader = NewDataReader(db.Postgres)
+		bundleWriter = NewBundleWriter(db.Postgres)
+		bundleReader = NewBundleReader(db.Postgres)
 	})
 
 	AfterEach(func() {
@@ -528,8 +527,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger serialization errors
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -552,8 +551,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger max retries
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -576,8 +575,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger transaction begin error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -600,8 +599,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger transaction query error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -624,8 +623,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger batch insert error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -650,8 +649,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger serialization errors
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -677,8 +676,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger max retries
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -706,8 +705,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger serialization errors
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -730,8 +729,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger max retries
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -756,8 +755,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger batch insert error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -780,8 +779,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger batch send error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -804,8 +803,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger batch result close error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -828,8 +827,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger transaction commit error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -854,8 +853,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger transaction begin error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -881,8 +880,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger transaction query error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -908,8 +907,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger batch delete error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -935,8 +934,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger batch delete error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -962,8 +961,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger batch send error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -989,8 +988,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger batch result close error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -1016,8 +1015,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger transaction commit error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -1045,8 +1044,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger transaction begin error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -1069,8 +1068,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger transaction query error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)
@@ -1093,8 +1092,8 @@ var _ = Describe("DataWriter", func() {
 				ctx := context.Background()
 
 				// Create a dataWriter with a closed database to trigger transaction commit error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				writerWithClosedDB := NewDataWriter(closedDB)

--- a/internal/storage/postgres/gc/gc_test.go
+++ b/internal/storage/postgres/gc/gc_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Permify/permify/internal/storage/postgres"
 	"github.com/Permify/permify/pkg/attribute"
 	"github.com/Permify/permify/pkg/database"
-	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 	"github.com/Permify/permify/pkg/dsl/compiler"
 	"github.com/Permify/permify/pkg/dsl/parser"
 	base "github.com/Permify/permify/pkg/pb/base/v1"
@@ -31,7 +30,7 @@ func TestGC(t *testing.T) {
 }
 
 var _ = Describe("GarbageCollector", func() {
-	var db database.Database
+	var db *testinstance.PostgresInstance
 	var ctx context.Context
 	var garbageCollector *GC
 	var tenantWriter *postgres.TenantWriter
@@ -49,16 +48,16 @@ var _ = Describe("GarbageCollector", func() {
 
 		db = testinstance.PostgresDB(version)
 		garbageCollector = NewGC(
-			db.(*PQDatabase.Postgres),
+			db.Postgres,
 			Window(5*time.Second),
 		)
 
-		tenantWriter = postgres.NewTenantWriter(db.(*PQDatabase.Postgres))
-		schemaWriter = postgres.NewSchemaWriter(db.(*PQDatabase.Postgres))
-		dataWriter = postgres.NewDataWriter(db.(*PQDatabase.Postgres))
+		tenantWriter = postgres.NewTenantWriter(db.Postgres)
+		schemaWriter = postgres.NewSchemaWriter(db.Postgres)
+		dataWriter = postgres.NewDataWriter(db.Postgres)
 
-		schemaReader = postgres.NewSchemaReader(db.(*PQDatabase.Postgres))
-		dataReader = postgres.NewDataReader(db.(*PQDatabase.Postgres))
+		schemaReader = postgres.NewSchemaReader(db.Postgres)
+		dataReader = postgres.NewDataReader(db.Postgres)
 	})
 
 	AfterEach(func() {
@@ -376,7 +375,7 @@ var _ = Describe("GarbageCollector", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			badGC := NewGC(
-				closedDB.(*PQDatabase.Postgres),
+				closedDB.Postgres,
 				Window(5*time.Second),
 			)
 
@@ -486,7 +485,7 @@ var _ = Describe("GarbageCollector", func() {
 		It("should handle Run with timeout", func() {
 			// Create a GC with very short timeout
 			shortTimeoutGC := NewGC(
-				db.(*PQDatabase.Postgres),
+				db.Postgres,
 				Window(5*time.Second),
 				Timeout(1*time.Nanosecond), // Very short timeout
 			)
@@ -610,7 +609,7 @@ var _ = Describe("GarbageCollector", func() {
 
 			// Get transaction count before GC
 			var transactionCountBefore int
-			err = db.(*PQDatabase.Postgres).WritePool.QueryRow(ctx,
+			err = db.Postgres.WritePool.QueryRow(ctx,
 				"SELECT COUNT(*) FROM "+postgres.TransactionsTable+" WHERE tenant_id = $1",
 				tenantID).Scan(&transactionCountBefore)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -626,7 +625,7 @@ var _ = Describe("GarbageCollector", func() {
 			// Verify old transactions were deleted by deleteTransactionsForTenant
 			// We should have fewer transactions now (only recent ones remain)
 			var transactionCountAfter int
-			err = db.(*PQDatabase.Postgres).WritePool.QueryRow(ctx,
+			err = db.Postgres.WritePool.QueryRow(ctx,
 				"SELECT COUNT(*) FROM "+postgres.TransactionsTable+" WHERE tenant_id = $1",
 				tenantID).Scan(&transactionCountAfter)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -638,7 +637,7 @@ var _ = Describe("GarbageCollector", func() {
 			// Create a fresh database instance with no custom tenants
 			freshDB := testinstance.PostgresDB("14")
 			freshGC := NewGC(
-				freshDB.(*PQDatabase.Postgres),
+				freshDB.Postgres,
 				Window(5*time.Second),
 			)
 

--- a/internal/storage/postgres/gc/gc_test.go
+++ b/internal/storage/postgres/gc/gc_test.go
@@ -371,6 +371,7 @@ var _ = Describe("GarbageCollector", func() {
 			// This tests errors at various stages: getting database time, getAllTenants,
 			// getLastTransactionIDForTenant, deleteRecordsForTenant, deleteTransactionsForTenant
 			closedDB := testinstance.PostgresDB("14")
+			DeferCleanup(func() { _ = closedDB.Close() })
 			err := closedDB.Close()
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -636,6 +637,7 @@ var _ = Describe("GarbageCollector", func() {
 		It("should handle getAllTenants with empty result", func() {
 			// Create a fresh database instance with no custom tenants
 			freshDB := testinstance.PostgresDB("14")
+			DeferCleanup(func() { _ = freshDB.Close() })
 			freshGC := NewGC(
 				freshDB.Postgres,
 				Window(5*time.Second),

--- a/internal/storage/postgres/gc/options_test.go
+++ b/internal/storage/postgres/gc/options_test.go
@@ -6,16 +6,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 	"github.com/Permify/permify/pkg/testinstance"
 )
 
 var _ = Describe("GC Options", func() {
-	var db *PQDatabase.Postgres
+	var db *testinstance.PostgresInstance
 
 	BeforeEach(func() {
 		version := "14"
-		db = testinstance.PostgresDB(version).(*PQDatabase.Postgres)
+		db = testinstance.PostgresDB(version)
 	})
 
 	AfterEach(func() {
@@ -29,7 +28,7 @@ var _ = Describe("GC Options", func() {
 		It("should set interval option correctly", func() {
 			expectedInterval := 30 * time.Second
 
-			gc := NewGC(db, Interval(expectedInterval))
+			gc := NewGC(db.Postgres, Interval(expectedInterval))
 
 			Expect(gc.interval).Should(Equal(expectedInterval))
 		})
@@ -37,7 +36,7 @@ var _ = Describe("GC Options", func() {
 		It("should set window option correctly", func() {
 			expectedWindow := 10 * time.Minute
 
-			gc := NewGC(db, Window(expectedWindow))
+			gc := NewGC(db.Postgres, Window(expectedWindow))
 
 			Expect(gc.window).Should(Equal(expectedWindow))
 		})
@@ -45,7 +44,7 @@ var _ = Describe("GC Options", func() {
 		It("should set timeout option correctly", func() {
 			expectedTimeout := 5 * time.Minute
 
-			gc := NewGC(db, Timeout(expectedTimeout))
+			gc := NewGC(db.Postgres, Timeout(expectedTimeout))
 
 			Expect(gc.timeout).Should(Equal(expectedTimeout))
 		})
@@ -55,7 +54,7 @@ var _ = Describe("GC Options", func() {
 			expectedWindow := 15 * time.Minute
 			expectedTimeout := 8 * time.Minute
 
-			gc := NewGC(db,
+			gc := NewGC(db.Postgres,
 				Interval(expectedInterval),
 				Window(expectedWindow),
 				Timeout(expectedTimeout),
@@ -70,7 +69,7 @@ var _ = Describe("GC Options", func() {
 			firstInterval := 30 * time.Second
 			secondInterval := 60 * time.Second
 
-			gc := NewGC(db,
+			gc := NewGC(db.Postgres,
 				Interval(firstInterval),
 				Interval(secondInterval),
 			)
@@ -79,7 +78,7 @@ var _ = Describe("GC Options", func() {
 		})
 
 		It("should use default values when no options are provided", func() {
-			gc := NewGC(db)
+			gc := NewGC(db.Postgres)
 
 			Expect(gc.interval).Should(Equal(_defaultInterval))
 			Expect(gc.window).Should(Equal(_defaultWindow))
@@ -87,7 +86,7 @@ var _ = Describe("GC Options", func() {
 		})
 
 		It("should handle zero duration values", func() {
-			gc := NewGC(db,
+			gc := NewGC(db.Postgres,
 				Interval(0),
 				Window(0),
 				Timeout(0),
@@ -101,7 +100,7 @@ var _ = Describe("GC Options", func() {
 		It("should handle negative duration values", func() {
 			negativeDuration := -5 * time.Second
 
-			gc := NewGC(db,
+			gc := NewGC(db.Postgres,
 				Interval(negativeDuration),
 				Window(negativeDuration),
 				Timeout(negativeDuration),
@@ -115,7 +114,7 @@ var _ = Describe("GC Options", func() {
 		It("should handle very large duration values", func() {
 			largeDuration := 24 * time.Hour
 
-			gc := NewGC(db,
+			gc := NewGC(db.Postgres,
 				Interval(largeDuration),
 				Window(largeDuration),
 				Timeout(largeDuration),
@@ -127,13 +126,13 @@ var _ = Describe("GC Options", func() {
 		})
 
 		It("should maintain database reference when options are applied", func() {
-			gc := NewGC(db,
+			gc := NewGC(db.Postgres,
 				Interval(30*time.Second),
 				Window(10*time.Minute),
 				Timeout(5*time.Minute),
 			)
 
-			Expect(gc.database).Should(Equal(db))
+			Expect(gc.database).Should(Equal(db.Postgres))
 		})
 
 		It("should allow chaining of option functions", func() {
@@ -146,7 +145,7 @@ var _ = Describe("GC Options", func() {
 			windowOption := Window(window)
 			timeoutOption := Timeout(timeout)
 
-			gc := NewGC(db, intervalOption, windowOption, timeoutOption)
+			gc := NewGC(db.Postgres, intervalOption, windowOption, timeoutOption)
 
 			Expect(gc.interval).Should(Equal(interval))
 			Expect(gc.window).Should(Equal(window))
@@ -159,9 +158,9 @@ var _ = Describe("GC Options", func() {
 			timeout := 8 * time.Minute
 
 			// Test different orders of options
-			gc1 := NewGC(db, Interval(interval), Window(window), Timeout(timeout))
-			gc2 := NewGC(db, Timeout(timeout), Interval(interval), Window(window))
-			gc3 := NewGC(db, Window(window), Timeout(timeout), Interval(interval))
+			gc1 := NewGC(db.Postgres, Interval(interval), Window(window), Timeout(timeout))
+			gc2 := NewGC(db.Postgres, Timeout(timeout), Interval(interval), Window(window))
+			gc3 := NewGC(db.Postgres, Window(window), Timeout(timeout), Interval(interval))
 
 			Expect(gc1.interval).Should(Equal(interval))
 			Expect(gc1.window).Should(Equal(window))
@@ -186,7 +185,7 @@ var _ = Describe("GC Options", func() {
 			Expect(option).ShouldNot(BeNil())
 
 			// Create a GC instance and apply the option
-			gc := NewGC(db)
+			gc := NewGC(db.Postgres)
 			originalInterval := gc.interval
 
 			// Apply the option
@@ -201,8 +200,8 @@ var _ = Describe("GC Options", func() {
 			interval1 := 30 * time.Second
 			interval2 := 60 * time.Second
 
-			gc1 := NewGC(db, Interval(interval1))
-			gc2 := NewGC(db, Interval(interval2))
+			gc1 := NewGC(db.Postgres, Interval(interval1))
+			gc2 := NewGC(db.Postgres, Interval(interval2))
 
 			Expect(gc1.interval).Should(Equal(interval1))
 			Expect(gc2.interval).Should(Equal(interval2))
@@ -213,8 +212,8 @@ var _ = Describe("GC Options", func() {
 			interval := 30 * time.Second
 			option := Interval(interval)
 
-			gc1 := NewGC(db)
-			gc2 := NewGC(db)
+			gc1 := NewGC(db.Postgres)
+			gc2 := NewGC(db.Postgres)
 
 			// Apply the same option to both instances
 			option(gc1)

--- a/internal/storage/postgres/schema_reader_test.go
+++ b/internal/storage/postgres/schema_reader_test.go
@@ -12,13 +12,12 @@ import (
 
 	"github.com/Permify/permify/internal/storage"
 	"github.com/Permify/permify/pkg/database"
-	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 	base "github.com/Permify/permify/pkg/pb/base/v1"
 	"github.com/Permify/permify/pkg/testinstance"
 )
 
 var _ = Describe("SchemaReader", func() {
-	var db database.Database
+	var db *testinstance.PostgresInstance
 	var schemaWriter *SchemaWriter
 	var schemaReader *SchemaReader
 
@@ -30,8 +29,8 @@ var _ = Describe("SchemaReader", func() {
 		}
 
 		db = testinstance.PostgresDB(version)
-		schemaWriter = NewSchemaWriter(db.(*PQDatabase.Postgres))
-		schemaReader = NewSchemaReader(db.(*PQDatabase.Postgres))
+		schemaWriter = NewSchemaWriter(db.Postgres)
+		schemaReader = NewSchemaReader(db.Postgres)
 	})
 
 	AfterEach(func() {
@@ -244,8 +243,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -263,8 +262,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger execution error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -282,8 +281,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -301,8 +300,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger internal error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -323,8 +322,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -342,8 +341,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger execution error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -361,8 +360,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -382,8 +381,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -410,8 +409,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -429,8 +428,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger internal error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -451,8 +450,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -479,8 +478,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -498,8 +497,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger internal error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -520,8 +519,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -548,8 +547,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -580,8 +579,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -600,8 +599,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger execution error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -620,8 +619,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)
@@ -640,8 +639,8 @@ var _ = Describe("SchemaReader", func() {
 				ctx := context.Background()
 
 				// Create a schemaReader with a closed database to trigger internal error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				readerWithClosedDB := NewSchemaReader(closedDB)

--- a/internal/storage/postgres/schema_writer_test.go
+++ b/internal/storage/postgres/schema_writer_test.go
@@ -10,14 +10,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/Permify/permify/internal/storage"
-	"github.com/Permify/permify/pkg/database"
-	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 	base "github.com/Permify/permify/pkg/pb/base/v1"
 	"github.com/Permify/permify/pkg/testinstance"
 )
 
 var _ = Describe("SchemaWriter", func() {
-	var db database.Database
+	var db *testinstance.PostgresInstance
 	var schemaWriter *SchemaWriter
 	var schemaReader *SchemaReader
 
@@ -29,8 +27,8 @@ var _ = Describe("SchemaWriter", func() {
 		}
 
 		db = testinstance.PostgresDB(version)
-		schemaWriter = NewSchemaWriter(db.(*PQDatabase.Postgres))
-		schemaReader = NewSchemaReader(db.(*PQDatabase.Postgres))
+		schemaWriter = NewSchemaWriter(db.Postgres)
+		schemaReader = NewSchemaReader(db.Postgres)
 	})
 
 	AfterEach(func() {

--- a/internal/storage/postgres/tenant_reader_test.go
+++ b/internal/storage/postgres/tenant_reader_test.go
@@ -8,12 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/Permify/permify/pkg/database"
-	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 	"github.com/Permify/permify/pkg/testinstance"
 )
 
 var _ = Describe("TenantReader", func() {
-	var db database.Database
+	var db *testinstance.PostgresInstance
 	var tenantWriter *TenantWriter
 	var tenantReader *TenantReader
 
@@ -25,8 +24,8 @@ var _ = Describe("TenantReader", func() {
 		}
 
 		db = testinstance.PostgresDB(version)
-		tenantWriter = NewTenantWriter(db.(*PQDatabase.Postgres))
-		tenantReader = NewTenantReader(db.(*PQDatabase.Postgres))
+		tenantWriter = NewTenantWriter(db.Postgres)
+		tenantReader = NewTenantReader(db.Postgres)
 	})
 
 	AfterEach(func() {

--- a/internal/storage/postgres/tenant_writer_test.go
+++ b/internal/storage/postgres/tenant_writer_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Permify/permify/internal/storage"
 	"github.com/Permify/permify/pkg/database"
-	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 	base "github.com/Permify/permify/pkg/pb/base/v1"
 	"github.com/Permify/permify/pkg/testinstance"
 	"github.com/Permify/permify/pkg/tuple"
@@ -19,7 +18,7 @@ import (
 )
 
 var _ = Describe("TenantWriter", func() {
-	var db database.Database
+	var db *testinstance.PostgresInstance
 	var tenantWriter *TenantWriter
 
 	BeforeEach(func() {
@@ -30,7 +29,7 @@ var _ = Describe("TenantWriter", func() {
 		}
 
 		db = testinstance.PostgresDB(version)
-		tenantWriter = NewTenantWriter(db.(*PQDatabase.Postgres))
+		tenantWriter = NewTenantWriter(db.Postgres)
 	})
 
 	AfterEach(func() {
@@ -158,7 +157,7 @@ var _ = Describe("TenantWriter", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Create schema for the tenant
-			schemaWriter := NewSchemaWriter(db.(*PQDatabase.Postgres))
+			schemaWriter := NewSchemaWriter(db.Postgres)
 			version := xid.New().String()
 			schema := []storage.SchemaDefinition{
 				{TenantID: tenantID, Name: "user", SerializedDefinition: []byte("entity user {}"), Version: version},
@@ -173,7 +172,7 @@ var _ = Describe("TenantWriter", func() {
 
 			// Verify schema data was actually deleted by checking database directly
 			var schemaCount int
-			err = db.(*PQDatabase.Postgres).WritePool.QueryRow(ctx,
+			err = db.Postgres.WritePool.QueryRow(ctx,
 				"SELECT COUNT(*) FROM "+SchemaDefinitionTable+" WHERE tenant_id = $1",
 				tenantID).Scan(&schemaCount)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -188,7 +187,7 @@ var _ = Describe("TenantWriter", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Create relation tuples for the tenant
-			dataWriter := NewDataWriter(db.(*PQDatabase.Postgres))
+			dataWriter := NewDataWriter(db.Postgres)
 			tup, err := tuple.Tuple("organization:1#admin@user:user-1")
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -209,7 +208,7 @@ var _ = Describe("TenantWriter", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Create schema
-			schemaWriter := NewSchemaWriter(db.(*PQDatabase.Postgres))
+			schemaWriter := NewSchemaWriter(db.Postgres)
 			version := xid.New().String()
 			schema := []storage.SchemaDefinition{
 				{TenantID: tenantID, Name: "user", SerializedDefinition: []byte("entity user {}"), Version: version},
@@ -218,7 +217,7 @@ var _ = Describe("TenantWriter", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Create relation tuples
-			dataWriter := NewDataWriter(db.(*PQDatabase.Postgres))
+			dataWriter := NewDataWriter(db.Postgres)
 			tup, err := tuple.Tuple("user:1#admin@user:user-1")
 			Expect(err).ShouldNot(HaveOccurred())
 			_, err = dataWriter.Write(ctx, tenantID, database.NewTupleCollection(tup), database.NewAttributeCollection())
@@ -289,7 +288,7 @@ var _ = Describe("TenantWriter", func() {
 				err := separateDB.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				writerWithClosedDB := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				writerWithClosedDB := NewTenantWriter(separateDB.Postgres)
 
 				_, err = writerWithClosedDB.CreateTenant(ctx, "test_id", "test_name")
 				Expect(err).Should(HaveOccurred())
@@ -310,7 +309,7 @@ var _ = Describe("TenantWriter", func() {
 				err := separateDB.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				writerWithClosedDB := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				writerWithClosedDB := NewTenantWriter(separateDB.Postgres)
 
 				err = writerWithClosedDB.DeleteTenant(ctx, "test_id")
 				Expect(err).Should(HaveOccurred())
@@ -331,7 +330,7 @@ var _ = Describe("TenantWriter", func() {
 
 				// Create a separate database instance for this test
 				separateDB := testinstance.PostgresDB("14")
-				separateWriter := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				separateWriter := NewTenantWriter(separateDB.Postgres)
 
 				// Create tenant in separate DB
 				_, err = separateWriter.CreateTenant(ctx, tenantID, "Batch Exec Error Tenant")
@@ -342,7 +341,7 @@ var _ = Describe("TenantWriter", func() {
 				err = separateDB.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				writerWithClosedDB := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				writerWithClosedDB := NewTenantWriter(separateDB.Postgres)
 
 				err = writerWithClosedDB.DeleteTenant(ctx, tenantID)
 				Expect(err).Should(HaveOccurred())
@@ -358,7 +357,7 @@ var _ = Describe("TenantWriter", func() {
 
 				// Create a separate database instance for this test
 				separateDB := testinstance.PostgresDB("14")
-				separateWriter := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				separateWriter := NewTenantWriter(separateDB.Postgres)
 
 				// Create a tenant first
 				tenantID := "batch-exec-tenant-error"
@@ -370,7 +369,7 @@ var _ = Describe("TenantWriter", func() {
 				err = separateDB.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				writerWithClosedDB := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				writerWithClosedDB := NewTenantWriter(separateDB.Postgres)
 
 				err = writerWithClosedDB.DeleteTenant(ctx, tenantID)
 				Expect(err).Should(HaveOccurred())
@@ -390,7 +389,7 @@ var _ = Describe("TenantWriter", func() {
 				err := separateDB.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				writerWithClosedDB := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				writerWithClosedDB := NewTenantWriter(separateDB.Postgres)
 
 				err = writerWithClosedDB.DeleteTenant(ctx, "test_id")
 				Expect(err).Should(HaveOccurred())
@@ -406,7 +405,7 @@ var _ = Describe("TenantWriter", func() {
 
 				// Create a separate database instance for this test
 				separateDB := testinstance.PostgresDB("14")
-				separateWriter := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				separateWriter := NewTenantWriter(separateDB.Postgres)
 
 				// Create a tenant first
 				tenantID := "batch-close-error-tenant"
@@ -418,7 +417,7 @@ var _ = Describe("TenantWriter", func() {
 				err = separateDB.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				writerWithClosedDB := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				writerWithClosedDB := NewTenantWriter(separateDB.Postgres)
 
 				err = writerWithClosedDB.DeleteTenant(ctx, tenantID)
 				Expect(err).Should(HaveOccurred())
@@ -434,7 +433,7 @@ var _ = Describe("TenantWriter", func() {
 
 				// Create a separate database instance for this test
 				separateDB := testinstance.PostgresDB("14")
-				separateWriter := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				separateWriter := NewTenantWriter(separateDB.Postgres)
 
 				// Create a tenant first
 				tenantID := "batch-close-success-error-tenant"
@@ -446,7 +445,7 @@ var _ = Describe("TenantWriter", func() {
 				err = separateDB.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				writerWithClosedDB := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				writerWithClosedDB := NewTenantWriter(separateDB.Postgres)
 
 				err = writerWithClosedDB.DeleteTenant(ctx, tenantID)
 				Expect(err).Should(HaveOccurred())
@@ -462,7 +461,7 @@ var _ = Describe("TenantWriter", func() {
 
 				// Create a separate database instance for this test
 				separateDB := testinstance.PostgresDB("14")
-				separateWriter := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				separateWriter := NewTenantWriter(separateDB.Postgres)
 
 				// Create a tenant first
 				tenantID := "commit-error-tenant"
@@ -474,7 +473,7 @@ var _ = Describe("TenantWriter", func() {
 				err = separateDB.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
-				writerWithClosedDB := NewTenantWriter(separateDB.(*PQDatabase.Postgres))
+				writerWithClosedDB := NewTenantWriter(separateDB.Postgres)
 
 				err = writerWithClosedDB.DeleteTenant(ctx, tenantID)
 				Expect(err).Should(HaveOccurred())

--- a/internal/storage/postgres/tenant_writer_test.go
+++ b/internal/storage/postgres/tenant_writer_test.go
@@ -285,6 +285,7 @@ var _ = Describe("TenantWriter", func() {
 
 				// Create a separate database instance and close it to trigger execution error
 				separateDB := testinstance.PostgresDB("14")
+				DeferCleanup(func() { _ = separateDB.Close() })
 				err := separateDB.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -306,6 +307,7 @@ var _ = Describe("TenantWriter", func() {
 
 				// Create a separate database instance and close it to trigger transaction begin error
 				separateDB := testinstance.PostgresDB("14")
+				DeferCleanup(func() { _ = separateDB.Close() })
 				err := separateDB.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -330,6 +332,7 @@ var _ = Describe("TenantWriter", func() {
 
 				// Create a separate database instance for this test
 				separateDB := testinstance.PostgresDB("14")
+				DeferCleanup(func() { _ = separateDB.Close() })
 				separateWriter := NewTenantWriter(separateDB.Postgres)
 
 				// Create tenant in separate DB
@@ -357,6 +360,7 @@ var _ = Describe("TenantWriter", func() {
 
 				// Create a separate database instance for this test
 				separateDB := testinstance.PostgresDB("14")
+				DeferCleanup(func() { _ = separateDB.Close() })
 				separateWriter := NewTenantWriter(separateDB.Postgres)
 
 				// Create a tenant first
@@ -386,6 +390,7 @@ var _ = Describe("TenantWriter", func() {
 				// Create a separate database instance and close it to trigger connection errors
 				// This tests errors at various stages: transaction begin, query row, batch execution, commit
 				separateDB := testinstance.PostgresDB("14")
+				DeferCleanup(func() { _ = separateDB.Close() })
 				err := separateDB.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -405,6 +410,7 @@ var _ = Describe("TenantWriter", func() {
 
 				// Create a separate database instance for this test
 				separateDB := testinstance.PostgresDB("14")
+				DeferCleanup(func() { _ = separateDB.Close() })
 				separateWriter := NewTenantWriter(separateDB.Postgres)
 
 				// Create a tenant first
@@ -433,6 +439,7 @@ var _ = Describe("TenantWriter", func() {
 
 				// Create a separate database instance for this test
 				separateDB := testinstance.PostgresDB("14")
+				DeferCleanup(func() { _ = separateDB.Close() })
 				separateWriter := NewTenantWriter(separateDB.Postgres)
 
 				// Create a tenant first
@@ -461,6 +468,7 @@ var _ = Describe("TenantWriter", func() {
 
 				// Create a separate database instance for this test
 				separateDB := testinstance.PostgresDB("14")
+				DeferCleanup(func() { _ = separateDB.Close() })
 				separateWriter := NewTenantWriter(separateDB.Postgres)
 
 				// Create a tenant first

--- a/internal/storage/postgres/utils/common_test.go
+++ b/internal/storage/postgres/utils/common_test.go
@@ -463,6 +463,7 @@ var _ = Describe("Common", func() {
 
 				// Create a new database instance for this version
 				database := testinstance.PostgresDB(pgVersion)
+				DeferCleanup(func() { _ = database.Close() })
 				testDB := database
 				testPool := testDB.Postgres.WritePool
 
@@ -499,6 +500,7 @@ var _ = Describe("Common", func() {
 			}
 
 			database := testinstance.PostgresDB(version)
+			DeferCleanup(func() { _ = database.Close() })
 			db := database
 			writePool := db.Postgres.WritePool
 

--- a/internal/storage/postgres/utils/common_test.go
+++ b/internal/storage/postgres/utils/common_test.go
@@ -18,7 +18,6 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/Permify/permify/internal/storage/postgres/utils"
-	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 	base "github.com/Permify/permify/pkg/pb/base/v1"
 	"github.com/Permify/permify/pkg/testinstance"
 )
@@ -378,7 +377,7 @@ var _ = Describe("Common", func() {
 	})
 
 	Context("EnsureDBVersion", func() {
-		var db *PQDatabase.Postgres
+		var db *testinstance.PostgresInstance
 		var writePool *pgxpool.Pool
 
 		BeforeEach(func() {
@@ -388,8 +387,8 @@ var _ = Describe("Common", func() {
 			}
 
 			database := testinstance.PostgresDB(version)
-			db = database.(*PQDatabase.Postgres)
-			writePool = db.WritePool
+			db = database
+			writePool = db.Postgres.WritePool
 		})
 
 		AfterEach(func() {
@@ -464,8 +463,8 @@ var _ = Describe("Common", func() {
 
 				// Create a new database instance for this version
 				database := testinstance.PostgresDB(pgVersion)
-				testDB := database.(*PQDatabase.Postgres)
-				testPool := testDB.WritePool
+				testDB := database
+				testPool := testDB.Postgres.WritePool
 
 				version, err := utils.EnsureDBVersion(testPool)
 
@@ -500,8 +499,8 @@ var _ = Describe("Common", func() {
 			}
 
 			database := testinstance.PostgresDB(version)
-			db := database.(*PQDatabase.Postgres)
-			writePool := db.WritePool
+			db := database
+			writePool := db.Postgres.WritePool
 
 			versionStr, err := utils.EnsureDBVersion(writePool)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/internal/storage/postgres/watch_test.go
+++ b/internal/storage/postgres/watch_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var _ = Describe("Watch", func() {
-	var db database.Database
+	var db *testinstance.PostgresInstance
 	var dataWriter *DataWriter
 	var watcher *Watch
 
@@ -30,8 +30,8 @@ var _ = Describe("Watch", func() {
 		}
 
 		db = testinstance.PostgresDB(version)
-		dataWriter = NewDataWriter(db.(*PQDatabase.Postgres))
-		watcher = NewWatcher(db.(*PQDatabase.Postgres))
+		dataWriter = NewDataWriter(db.Postgres)
+		watcher = NewWatcher(db.Postgres)
 	})
 
 	AfterEach(func() {
@@ -135,8 +135,8 @@ var _ = Describe("Watch", func() {
 				ctx := context.Background()
 
 				// Create a watcher with a closed database to trigger get changes error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				watcherWithClosedDB := NewWatcher(closedDB)
@@ -186,8 +186,8 @@ var _ = Describe("Watch", func() {
 				ctx := context.Background()
 
 				// Create a watcher with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				watcherWithClosedDB := NewWatcher(closedDB)
@@ -201,8 +201,8 @@ var _ = Describe("Watch", func() {
 				ctx := context.Background()
 
 				// Create a watcher with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				watcherWithClosedDB := NewWatcher(closedDB)
@@ -216,8 +216,8 @@ var _ = Describe("Watch", func() {
 				ctx := context.Background()
 
 				// Create a watcher with a closed database to trigger rows error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				watcherWithClosedDB := NewWatcher(closedDB)
@@ -233,8 +233,8 @@ var _ = Describe("Watch", func() {
 				ctx := context.Background()
 
 				// Create a watcher with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				watcherWithClosedDB := NewWatcher(closedDB)
@@ -248,8 +248,8 @@ var _ = Describe("Watch", func() {
 				ctx := context.Background()
 
 				// Create a watcher with a closed database to trigger execution error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				watcherWithClosedDB := NewWatcher(closedDB)
@@ -263,8 +263,8 @@ var _ = Describe("Watch", func() {
 				ctx := context.Background()
 
 				// Create a watcher with a closed database to trigger SQL builder error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				watcherWithClosedDB := NewWatcher(closedDB)
@@ -278,8 +278,8 @@ var _ = Describe("Watch", func() {
 				ctx := context.Background()
 
 				// Create a watcher with a closed database to trigger execution error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				watcherWithClosedDB := NewWatcher(closedDB)
@@ -293,8 +293,8 @@ var _ = Describe("Watch", func() {
 				ctx := context.Background()
 
 				// Create a watcher with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				watcherWithClosedDB := NewWatcher(closedDB)
@@ -308,8 +308,8 @@ var _ = Describe("Watch", func() {
 				ctx := context.Background()
 
 				// Create a watcher with a closed database to trigger scan error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				watcherWithClosedDB := NewWatcher(closedDB)
@@ -323,8 +323,8 @@ var _ = Describe("Watch", func() {
 				ctx := context.Background()
 
 				// Create a watcher with a closed database to trigger unmarshal error
-				closedDB := db.(*PQDatabase.Postgres)
-				err := closedDB.Close()
+				closedDB := db.Postgres
+				err := db.Close()
 				Expect(err).ShouldNot(HaveOccurred())
 
 				watcherWithClosedDB := NewWatcher(closedDB)

--- a/pkg/testinstance/postgres.go
+++ b/pkg/testinstance/postgres.go
@@ -2,7 +2,9 @@ package testinstance
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/onsi/gomega"
@@ -16,7 +18,44 @@ import (
 	PQDatabase "github.com/Permify/permify/pkg/database/postgres"
 )
 
-func PostgresDB(postgresVersion string) database.Database {
+type PostgresInstance struct {
+	Postgres  *PQDatabase.Postgres
+	container testcontainers.Container
+	closeOnce sync.Once
+	closeErr  error
+}
+
+var _ database.Database = (*PostgresInstance)(nil)
+
+func (p *PostgresInstance) Close() error {
+	p.closeOnce.Do(func() {
+		var errs []error
+
+		if p.Postgres != nil {
+			errs = append(errs, p.Postgres.Close())
+		}
+
+		if p.container != nil {
+			terminateCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			errs = append(errs, p.container.Terminate(terminateCtx))
+		}
+
+		p.closeErr = errors.Join(errs...)
+	})
+
+	return p.closeErr
+}
+
+func (p *PostgresInstance) GetEngineType() string {
+	return p.Postgres.GetEngineType()
+}
+
+func (p *PostgresInstance) IsReady(ctx context.Context) (bool, error) {
+	return p.Postgres.IsReady(ctx)
+}
+
+func PostgresDB(postgresVersion string) *PostgresInstance {
 	ctx := context.Background()
 
 	image := fmt.Sprintf("postgres:%s-alpine", postgresVersion)
@@ -35,27 +74,47 @@ func PostgresDB(postgresVersion string) database.Database {
 	})
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
+	var db *PQDatabase.Postgres
+
+	cleanup := func() {
+		if db != nil {
+			_ = db.Close()
+		}
+		if postgres != nil {
+			terminateCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = postgres.Terminate(terminateCtx)
+		}
+	}
+
+	expectNoError := func(err error) {
+		if err != nil {
+			cleanup()
+		}
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	}
+
 	// Execute the command in the container
 	_, _, execErr := postgres.Exec(ctx, []string{"psql", "-U", "postgres", "-c", "ALTER SYSTEM SET track_commit_timestamp = on;"})
-	gomega.Expect(execErr).ShouldNot(gomega.HaveOccurred())
+	expectNoError(execErr)
 
 	stopTimeout := 2 * time.Second
 	err = postgres.Stop(context.Background(), &stopTimeout)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	expectNoError(err)
 
 	err = postgres.Start(context.Background())
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	expectNoError(err)
 
 	cmd := []string{"sh", "-c", "export PGPASSWORD=postgres" + "; psql -U postgres -d permify -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'"}
 
 	_, _, err = postgres.Exec(ctx, cmd)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	expectNoError(err)
 
 	host, err := postgres.Host(ctx)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	expectNoError(err)
 
 	port, err := postgres.MappedPort(ctx, "5432")
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	expectNoError(err)
 
 	dbAddr := fmt.Sprintf("%s:%s", host, port.Port())
 	postgresDSN := fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable", "postgres", "postgres", dbAddr, "permify")
@@ -71,19 +130,21 @@ func PostgresDB(postgresVersion string) database.Database {
 	}
 
 	err = storage.Migrate(cfg)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	expectNoError(err)
 
-	var db database.Database
 	db, err = PQDatabase.New(cfg.URI,
 		PQDatabase.MaxOpenConnections(cfg.MaxOpenConnections),
 		PQDatabase.MaxIdleConnections(cfg.MaxIdleConnections),
 		PQDatabase.MaxConnectionIdleTime(cfg.MaxConnectionIdleTime),
 		PQDatabase.MaxConnectionLifeTime(cfg.MaxConnectionLifetime),
 	)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	expectNoError(err)
 
-	_, err = utils.EnsureDBVersion(db.(*PQDatabase.Postgres).WritePool)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	_, err = utils.EnsureDBVersion(db.WritePool)
+	expectNoError(err)
 
-	return db
+	return &PostgresInstance{
+		Postgres:  db,
+		container: postgres,
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a test Postgres instance wrapper to centralize shutdown and cleanup, improving database lifecycle management and error-safe teardown.

* **Tests**
  * Updated numerous Postgres integration tests to use the wrapper’s underlying DB handle consistently, streamlining setup/teardown and making tests more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->