### PR TITLE
fix: improve coverage for permission condition branches

### DIFF
--- a/pkg/cmd/coverage.go
+++ b/pkg/cmd/coverage.go
@@ -131,6 +131,15 @@ func DisplayCoverageInfo(schemaCoverageInfo cov.SchemaCoverageInfo) {
 			}
 		}
 
+		fmt.Printf("  uncovered assertion components:\n")
+
+		for key, value := range entityCoverageInfo.UncoveredAssertionComponents {
+			fmt.Printf("    %s:\n", key)
+			for _, v := range value {
+				fmt.Printf("    	%v\n", v)
+			}
+		}
+
 		fmt.Printf("  coverage relationships percentage:")
 
 		if entityCoverageInfo.CoverageRelationshipsPercent <= 50 {
@@ -150,6 +159,17 @@ func DisplayCoverageInfo(schemaCoverageInfo cov.SchemaCoverageInfo) {
 		fmt.Printf("  coverage assertions percentage: \n")
 
 		for key, value := range entityCoverageInfo.CoverageAssertionsPercent {
+			fmt.Printf("    %s:", key)
+			if value <= 50 {
+				color.Danger.Printf(" %d%%\n", value)
+			} else {
+				color.Success.Printf(" %d%%\n", value)
+			}
+		}
+
+		fmt.Printf("  coverage assertion components percentage: \n")
+
+		for key, value := range entityCoverageInfo.CoverageAssertionComponentsPercent {
 			fmt.Printf("    %s:", key)
 			if value <= 50 {
 				color.Danger.Printf(" %d%%\n", value)

--- a/pkg/development/coverage/coverage.go
+++ b/pkg/development/coverage/coverage.go
@@ -175,20 +175,39 @@ func extractAssertions(entity *base.EntityDefinition) []string {
 // extractAssertionComponents extracts permission condition leaves from an entity.
 func extractAssertionComponents(entity *base.EntityDefinition) []string {
 	components := []string{}
+	permissions := make(map[string]*base.Child)
 
 	for _, permission := range entity.GetPermissions() {
-		components = append(components, extractChildAssertionComponents(entity.GetName(), permission.GetName(), permission.GetChild())...)
+		permissions[permission.GetName()] = permission.GetChild()
+	}
+
+	for _, permission := range entity.GetPermissions() {
+		components = append(components, extractChildAssertionComponents(
+			entity.GetName(),
+			permission.GetName(),
+			permission.GetChild(),
+			permissions,
+			map[string]bool{permission.GetName(): true},
+		)...)
 	}
 
 	return components
 }
 
-func extractChildAssertionComponents(entityName, permissionName string, child *base.Child) []string {
+func extractChildAssertionComponents(entityName, permissionName string, child *base.Child, permissions map[string]*base.Child, visited map[string]bool) []string {
 	if child == nil {
 		return []string{formatAssertion(entityName, permissionName)}
 	}
 
 	if leaf := child.GetLeaf(); leaf != nil {
+		if computed := leaf.GetComputedUserSet(); computed != nil {
+			relationName := computed.GetRelation()
+			if nestedChild, ok := permissions[relationName]; ok && !visited[relationName] {
+				nextVisited := cloneVisitedPermissions(visited)
+				nextVisited[relationName] = true
+				return extractChildAssertionComponents(entityName, permissionName, nestedChild, permissions, nextVisited)
+			}
+		}
 		if component := formatLeafAssertionComponent(entityName, permissionName, leaf); component != "" {
 			return []string{component}
 		}
@@ -198,12 +217,20 @@ func extractChildAssertionComponents(entityName, permissionName string, child *b
 	if rewrite := child.GetRewrite(); rewrite != nil {
 		components := []string{}
 		for _, rewriteChild := range rewrite.GetChildren() {
-			components = append(components, extractChildAssertionComponents(entityName, permissionName, rewriteChild)...)
+			components = append(components, extractChildAssertionComponents(entityName, permissionName, rewriteChild, permissions, visited)...)
 		}
 		return components
 	}
 
 	return []string{formatAssertion(entityName, permissionName)}
+}
+
+func cloneVisitedPermissions(visited map[string]bool) map[string]bool {
+	cloned := make(map[string]bool, len(visited)+1)
+	for name, isVisited := range visited {
+		cloned[name] = isVisited
+	}
+	return cloned
 }
 
 func formatLeafAssertionComponent(entityName, permissionName string, leaf *base.Leaf) string {

--- a/pkg/development/coverage/coverage.go
+++ b/pkg/development/coverage/coverage.go
@@ -74,6 +74,11 @@ type SchemaCoverage struct {
 	AssertionComponents []string
 }
 
+type assertionCoverageContext struct {
+	EntityID string
+	Subject  *base.Subject
+}
+
 // Run analyzes the coverage of relationships, attributes, and assertions
 // for a given schema shape and returns the coverage information
 func Run(shape file.Shape) SchemaCoverageInfo {
@@ -363,17 +368,56 @@ func findUncoveredAssertions(entityName string, expected []string, checks []file
 }
 
 func findUncoveredAssertionComponents(entityName string, expected []string, checks []file.Check, filters []file.EntityFilter, relationships, attributes []string) []string {
-	coveredAssertions := extractCoveredAssertions(entityName, checks, filters)
+	coverageContexts := extractAssertionCoverageContexts(entityName, checks, filters)
 	uncovered := []string{}
 
 	for _, component := range expected {
 		assertion := assertionFromComponent(component)
-		if !slices.Contains(coveredAssertions, assertion) || !assertionComponentHasSupportingData(entityName, component, relationships, attributes) {
+		if !assertionComponentHasSupportingData(entityName, component, coverageContexts[assertion], relationships, attributes) {
 			uncovered = append(uncovered, component)
 		}
 	}
 
 	return uncovered
+}
+
+func extractAssertionCoverageContexts(entityName string, checks []file.Check, filters []file.EntityFilter) map[string][]assertionCoverageContext {
+	contexts := make(map[string][]assertionCoverageContext)
+
+	for _, check := range checks {
+		entity, err := tuple.E(check.Entity)
+		if err != nil || entity.GetType() != entityName {
+			continue
+		}
+
+		subject := parseSubject(check.Subject)
+		for permission := range check.Assertions {
+			assertion := formatAssertion(entity.GetType(), permission)
+			contexts[assertion] = append(contexts[assertion], assertionCoverageContext{
+				EntityID: entity.GetId(),
+				Subject:  subject,
+			})
+		}
+	}
+
+	for _, filter := range filters {
+		if filter.EntityType != entityName {
+			continue
+		}
+
+		subject := parseSubject(filter.Subject)
+		for permission, entityIDs := range filter.Assertions {
+			assertion := formatAssertion(filter.EntityType, permission)
+			for _, entityID := range entityIDs {
+				contexts[assertion] = append(contexts[assertion], assertionCoverageContext{
+					EntityID: entityID,
+					Subject:  subject,
+				})
+			}
+		}
+	}
+
+	return contexts
 }
 
 // buildSchemaCoverageInfo builds the final SchemaCoverageInfo with total coverage
@@ -564,46 +608,102 @@ func componentName(component string) string {
 	return ""
 }
 
-func assertionComponentHasSupportingData(entityName, component string, relationships, attributes []string) bool {
+func assertionComponentHasSupportingData(entityName, component string, contexts []assertionCoverageContext, relationships, attributes []string) bool {
+	if len(contexts) == 0 {
+		return false
+	}
+
 	name := componentName(component)
 	if name == "" {
 		return true
 	}
+
 	if strings.Contains(name, ".") {
-		relationName := strings.SplitN(name, ".", 2)[0]
-		return relationshipRelationCovered(entityName, relationName, relationships)
+		parts := strings.SplitN(name, ".", 2)
+		return tupleToUserSetComponentCovered(entityName, parts[0], parts[1], contexts, relationships)
 	}
+
 	if strings.HasSuffix(name, "()") {
 		return true
 	}
-	if attributeCovered(entityName, name, attributes) {
-		return true
+
+	for _, context := range contexts {
+		if attributeCovered(entityName, context.EntityID, name, attributes) || relationshipRelationCovered(entityName, context.EntityID, name, relationships) {
+			return true
+		}
 	}
-	return relationshipRelationCovered(entityName, name, relationships)
+
+	return false
 }
 
-func relationshipRelationCovered(entityName, relationName string, relationships []string) bool {
+func relationshipRelationCovered(entityName, entityID, relationName string, relationships []string) bool {
 	for _, relationship := range relationships {
 		tup, err := tuple.Tuple(relationship)
 		if err != nil {
 			continue
 		}
-		if tup.GetEntity().GetType() == entityName && tup.GetRelation() == relationName {
+		if tup.GetEntity().GetType() == entityName && tup.GetEntity().GetId() == entityID && tup.GetRelation() == relationName {
 			return true
 		}
 	}
 	return false
 }
 
-func attributeCovered(entityName, attributeName string, attributes []string) bool {
+func attributeCovered(entityName, entityID, attributeName string, attributes []string) bool {
 	for _, attrStr := range attributes {
 		attr, err := attribute.Attribute(attrStr)
 		if err != nil {
 			continue
 		}
-		if attr.GetEntity().GetType() == entityName && attr.GetAttribute() == attributeName {
+		if attr.GetEntity().GetType() == entityName && attr.GetEntity().GetId() == entityID && attr.GetAttribute() == attributeName {
 			return true
 		}
 	}
 	return false
+}
+
+func tupleToUserSetComponentCovered(entityName, tupleRelationName, computedRelationName string, contexts []assertionCoverageContext, relationships []string) bool {
+	for _, context := range contexts {
+		for _, relationship := range relationships {
+			tup, err := tuple.Tuple(relationship)
+			if err != nil {
+				continue
+			}
+			if tup.GetEntity().GetType() != entityName || tup.GetEntity().GetId() != context.EntityID || tup.GetRelation() != tupleRelationName {
+				continue
+			}
+			if computedRelationCovered(tup.GetSubject(), computedRelationName, context.Subject, relationships) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func computedRelationCovered(source *base.Subject, computedRelationName string, expectedSubject *base.Subject, relationships []string) bool {
+	for _, relationship := range relationships {
+		tup, err := tuple.Tuple(relationship)
+		if err != nil {
+			continue
+		}
+		if tup.GetEntity().GetType() != source.GetType() || tup.GetEntity().GetId() != source.GetId() || tup.GetRelation() != computedRelationName {
+			continue
+		}
+		if expectedSubject == nil || tuple.AreSubjectsEqual(tup.GetSubject(), expectedSubject) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseSubject(subject string) *base.Subject {
+	ear, err := tuple.EAR(subject)
+	if err != nil {
+		return nil
+	}
+	return &base.Subject{
+		Type:     ear.GetEntity().GetType(),
+		Id:       ear.GetEntity().GetId(),
+		Relation: ear.GetRelation(),
+	}
 }

--- a/pkg/development/coverage/coverage.go
+++ b/pkg/development/coverage/coverage.go
@@ -3,6 +3,7 @@ package coverage
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/Permify/permify/pkg/attribute"
 	"github.com/Permify/permify/pkg/development/file"
@@ -32,6 +33,9 @@ type EntityCoverageInfo struct {
 
 	UncoveredAssertions       map[string][]string
 	CoverageAssertionsPercent map[string]int
+
+	UncoveredAssertionComponents       map[string][]string
+	CoverageAssertionComponentsPercent map[string]int
 }
 
 // SchemaCoverage represents the expected coverage for a schema entity
@@ -63,10 +67,11 @@ type EntityCoverageInfo struct {
 //   - repository#edit
 //   - repository#delete
 type SchemaCoverage struct {
-	EntityName    string
-	Relationships []string
-	Attributes    []string
-	Assertions    []string
+	EntityName          string
+	Relationships       []string
+	Attributes          []string
+	Assertions          []string
+	AssertionComponents []string
 }
 
 // Run analyzes the coverage of relationships, attributes, and assertions
@@ -110,10 +115,11 @@ func extractSchemaReferences(definitions []*base.EntityDefinition) []SchemaCover
 // extractEntityReferences extracts relationships, attributes, and assertions from an entity definition
 func extractEntityReferences(entity *base.EntityDefinition) SchemaCoverage {
 	coverage := SchemaCoverage{
-		EntityName:    entity.GetName(),
-		Relationships: extractRelationships(entity),
-		Attributes:    extractAttributes(entity),
-		Assertions:    extractAssertions(entity),
+		EntityName:          entity.GetName(),
+		Relationships:       extractRelationships(entity),
+		Attributes:          extractAttributes(entity),
+		Assertions:          extractAssertions(entity),
+		AssertionComponents: extractAssertionComponents(entity),
 	}
 	return coverage
 }
@@ -159,6 +165,69 @@ func extractAssertions(entity *base.EntityDefinition) []string {
 	}
 
 	return assertions
+}
+
+// extractAssertionComponents extracts permission condition leaves from an entity.
+func extractAssertionComponents(entity *base.EntityDefinition) []string {
+	components := []string{}
+
+	for _, permission := range entity.GetPermissions() {
+		components = append(components, extractChildAssertionComponents(entity.GetName(), permission.GetName(), permission.GetChild())...)
+	}
+
+	return components
+}
+
+func extractChildAssertionComponents(entityName, permissionName string, child *base.Child) []string {
+	if child == nil {
+		return []string{formatAssertion(entityName, permissionName)}
+	}
+
+	if leaf := child.GetLeaf(); leaf != nil {
+		if component := formatLeafAssertionComponent(entityName, permissionName, leaf); component != "" {
+			return []string{component}
+		}
+		return []string{formatAssertion(entityName, permissionName)}
+	}
+
+	if rewrite := child.GetRewrite(); rewrite != nil {
+		components := []string{}
+		for _, rewriteChild := range rewrite.GetChildren() {
+			components = append(components, extractChildAssertionComponents(entityName, permissionName, rewriteChild)...)
+		}
+		return components
+	}
+
+	return []string{formatAssertion(entityName, permissionName)}
+}
+
+func formatLeafAssertionComponent(entityName, permissionName string, leaf *base.Leaf) string {
+	switch leaf.GetType().(type) {
+	case *base.Leaf_ComputedUserSet:
+		if computed := leaf.GetComputedUserSet(); computed != nil {
+			return formatAssertionComponent(entityName, permissionName, computed.GetRelation())
+		}
+	case *base.Leaf_TupleToUserSet:
+		tupleToUserSet := leaf.GetTupleToUserSet()
+		if tupleToUserSet != nil && tupleToUserSet.GetTupleSet() != nil && tupleToUserSet.GetComputed() != nil {
+			return formatAssertionComponent(
+				entityName,
+				permissionName,
+				fmt.Sprintf("%s.%s", tupleToUserSet.GetTupleSet().GetRelation(), tupleToUserSet.GetComputed().GetRelation()),
+			)
+		}
+	case *base.Leaf_ComputedAttribute:
+		if computed := leaf.GetComputedAttribute(); computed != nil {
+			return formatAssertionComponent(entityName, permissionName, computed.GetName())
+		}
+	case *base.Leaf_Call:
+		if call := leaf.GetCall(); call != nil {
+			return formatAssertionComponent(entityName, permissionName, fmt.Sprintf("%s()", call.GetRuleName()))
+		}
+	default:
+		return ""
+	}
+	return ""
 }
 
 // calculateEntityCoverages calculates coverage for all entities
@@ -215,6 +284,22 @@ func calculateEntityCoverage(ref SchemaCoverage, shape file.Shape) EntityCoverag
 			ref.Assertions,
 			uncovered,
 		)
+
+		uncoveredComponents := findUncoveredAssertionComponents(
+			ref.EntityName,
+			ref.AssertionComponents,
+			scenario.Checks,
+			scenario.EntityFilters,
+			shape.Relationships,
+			shape.Attributes,
+		)
+		if len(uncoveredComponents) > 0 {
+			entityCoverageInfo.UncoveredAssertionComponents[scenario.Name] = uncoveredComponents
+		}
+		entityCoverageInfo.CoverageAssertionComponentsPercent[scenario.Name] = calculateCoveragePercent(
+			ref.AssertionComponents,
+			uncoveredComponents,
+		)
 	}
 
 	return entityCoverageInfo
@@ -223,13 +308,15 @@ func calculateEntityCoverage(ref SchemaCoverage, shape file.Shape) EntityCoverag
 // newEntityCoverageInfo creates a new EntityCoverageInfo with initialized fields
 func newEntityCoverageInfo(entityName string) EntityCoverageInfo {
 	return EntityCoverageInfo{
-		EntityName:                   entityName,
-		UncoveredRelationships:       []string{},
-		UncoveredAttributes:          []string{},
-		CoverageAssertionsPercent:    make(map[string]int),
-		UncoveredAssertions:          make(map[string][]string),
-		CoverageRelationshipsPercent: 0,
-		CoverageAttributesPercent:    0,
+		EntityName:                         entityName,
+		UncoveredRelationships:             []string{},
+		UncoveredAttributes:                []string{},
+		CoverageAssertionsPercent:          make(map[string]int),
+		UncoveredAssertions:                make(map[string][]string),
+		CoverageAssertionComponentsPercent: make(map[string]int),
+		UncoveredAssertionComponents:       make(map[string][]string),
+		CoverageRelationshipsPercent:       0,
+		CoverageAttributesPercent:          0,
 	}
 }
 
@@ -269,6 +356,20 @@ func findUncoveredAssertions(entityName string, expected []string, checks []file
 	for _, assertion := range expected {
 		if !slices.Contains(covered, assertion) {
 			uncovered = append(uncovered, assertion)
+		}
+	}
+
+	return uncovered
+}
+
+func findUncoveredAssertionComponents(entityName string, expected []string, checks []file.Check, filters []file.EntityFilter, relationships, attributes []string) []string {
+	coveredAssertions := extractCoveredAssertions(entityName, checks, filters)
+	uncovered := []string{}
+
+	for _, component := range expected {
+		assertion := assertionFromComponent(component)
+		if !slices.Contains(coveredAssertions, assertion) || !assertionComponentHasSupportingData(entityName, component, relationships, attributes) {
+			uncovered = append(uncovered, component)
 		}
 	}
 
@@ -316,7 +417,7 @@ func calculateTotalCoverage(entities []EntityCoverageInfo) (int, int, int) {
 		totalAttributes++
 		totalCoveredAttributes += entity.CoverageAttributesPercent
 
-		for _, assertionPercent := range entity.CoverageAssertionsPercent {
+		for _, assertionPercent := range entity.CoverageAssertionComponentsPercent {
 			totalAssertions++
 			totalCoveredAssertions += assertionPercent
 		}
@@ -434,4 +535,75 @@ func formatAttribute(entityName, attributeName string) string {
 // formatAssertion formats an assertion/permission string
 func formatAssertion(entityName, permissionName string) string {
 	return fmt.Sprintf("%s#%s", entityName, permissionName)
+}
+
+func formatAssertionComponent(entityName, permissionName, componentName string) string {
+	return fmt.Sprintf("%s#%s[%s]", entityName, permissionName, componentName)
+}
+
+func assertionFromComponent(component string) string {
+	for idx, ch := range component {
+		if ch == '[' {
+			return component[:idx]
+		}
+	}
+	return component
+}
+
+func componentName(component string) string {
+	start := -1
+	for idx, ch := range component {
+		if ch == '[' {
+			start = idx + 1
+			continue
+		}
+		if ch == ']' && start >= 0 {
+			return component[start:idx]
+		}
+	}
+	return ""
+}
+
+func assertionComponentHasSupportingData(entityName, component string, relationships, attributes []string) bool {
+	name := componentName(component)
+	if name == "" {
+		return true
+	}
+	if strings.Contains(name, ".") {
+		relationName := strings.SplitN(name, ".", 2)[0]
+		return relationshipRelationCovered(entityName, relationName, relationships)
+	}
+	if strings.HasSuffix(name, "()") {
+		return true
+	}
+	if attributeCovered(entityName, name, attributes) {
+		return true
+	}
+	return relationshipRelationCovered(entityName, name, relationships)
+}
+
+func relationshipRelationCovered(entityName, relationName string, relationships []string) bool {
+	for _, relationship := range relationships {
+		tup, err := tuple.Tuple(relationship)
+		if err != nil {
+			continue
+		}
+		if tup.GetEntity().GetType() == entityName && tup.GetRelation() == relationName {
+			return true
+		}
+	}
+	return false
+}
+
+func attributeCovered(entityName, attributeName string, attributes []string) bool {
+	for _, attrStr := range attributes {
+		attr, err := attribute.Attribute(attrStr)
+		if err != nil {
+			continue
+		}
+		if attr.GetEntity().GetType() == entityName && attr.GetAttribute() == attributeName {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/development/coverage/coverage_test.go
+++ b/pkg/development/coverage/coverage_test.go
@@ -291,6 +291,50 @@ var _ = Describe("coverage", func() {
 			Expect(sci.TotalAssertionsCoverage).Should(Equal(66))
 		})
 
+		It("Case 2.2: Does not cover a permission component from a different entity instance", func() {
+			sci := Run(file.Shape{
+				Schema: `
+		entity user {}
+
+		entity document {
+			relation system @user
+			relation viewer @user
+			relation owner @user
+
+			permission view = system or (viewer or owner)
+		}`,
+				Relationships: []string{
+					"document:2#system@user:1",
+				},
+				Scenarios: []file.Scenario{
+					{
+						Name:        "scenario 1",
+						Description: "supporting tuple belongs to another document",
+						Checks: []file.Check{
+							{
+								Entity:  "document:1",
+								Subject: "user:1",
+								Assertions: map[string]bool{
+									"view": true,
+								},
+							},
+						},
+						EntityFilters: []file.EntityFilter{},
+					},
+				},
+			})
+
+			Expect(sci.EntityCoverageInfo[1].EntityName).Should(Equal("document"))
+			Expect(sci.EntityCoverageInfo[1].UncoveredAssertions).Should(Equal(map[string][]string{}))
+			Expect(isSameArray(sci.EntityCoverageInfo[1].UncoveredAssertionComponents["scenario 1"], []string{
+				"document#view[owner]",
+				"document#view[system]",
+				"document#view[viewer]",
+			})).Should(Equal(true))
+			Expect(sci.EntityCoverageInfo[1].CoverageAssertionComponentsPercent["scenario 1"]).Should(Equal(0))
+			Expect(sci.TotalAssertionsCoverage).Should(Equal(50))
+		})
+
 		It("Case 3: Facebook Groups", func() {
 			sci := Run(file.Shape{
 				Schema: `

--- a/pkg/development/coverage/coverage_test.go
+++ b/pkg/development/coverage/coverage_test.go
@@ -288,6 +288,7 @@ var _ = Describe("coverage", func() {
 				"document#view[viewer]",
 			})).Should(Equal(true))
 			Expect(sci.EntityCoverageInfo[1].CoverageAssertionComponentsPercent["scenario 1"]).Should(Equal(33))
+			// TotalAssertionsCoverage averages user coverage (100%) and document component coverage (33%).
 			Expect(sci.TotalAssertionsCoverage).Should(Equal(66))
 		})
 

--- a/pkg/development/coverage/coverage_test.go
+++ b/pkg/development/coverage/coverage_test.go
@@ -335,6 +335,51 @@ var _ = Describe("coverage", func() {
 			Expect(sci.TotalAssertionsCoverage).Should(Equal(50))
 		})
 
+		It("Case 2.3: Expands nested same-entity permissions into leaf components", func() {
+			sci := Run(file.Shape{
+				Schema: `
+		entity user {}
+
+		entity document {
+			relation system @user
+			relation viewer @user
+			relation owner @user
+
+			permission can_view = system or viewer
+			permission view = can_view or owner
+		}`,
+				Relationships: []string{
+					"document:1#viewer@user:1",
+				},
+				Scenarios: []file.Scenario{
+					{
+						Name:        "scenario 1",
+						Description: "exercises one branch through a nested permission",
+						Checks: []file.Check{
+							{
+								Entity:  "document:1",
+								Subject: "user:1",
+								Assertions: map[string]bool{
+									"can_view": true,
+									"view":     true,
+								},
+							},
+						},
+						EntityFilters: []file.EntityFilter{},
+					},
+				},
+			})
+
+			Expect(sci.EntityCoverageInfo[1].EntityName).Should(Equal("document"))
+			Expect(sci.EntityCoverageInfo[1].UncoveredAssertionComponents["scenario 1"]).Should(ConsistOf([]string{
+				"document#can_view[system]",
+				"document#view[owner]",
+				"document#view[system]",
+			}))
+			Expect(sci.EntityCoverageInfo[1].CoverageAssertionComponentsPercent["scenario 1"]).Should(Equal(40))
+			Expect(sci.TotalAssertionsCoverage).Should(Equal(70))
+		})
+
 		It("Case 3: Facebook Groups", func() {
 			sci := Run(file.Shape{
 				Schema: `

--- a/pkg/development/coverage/coverage_test.go
+++ b/pkg/development/coverage/coverage_test.go
@@ -247,6 +247,50 @@ var _ = Describe("coverage", func() {
 			Expect(sci.EntityCoverageInfo[3].CoverageAssertionsPercent["scenario 1"]).Should(Equal(0))
 		})
 
+		It("Case 2.1: Tracks partially covered permission conditions", func() {
+			sci := Run(file.Shape{
+				Schema: `
+		entity user {}
+
+		entity document {
+			relation system @user
+			relation viewer @user
+			relation owner @user
+
+			permission view = system or (viewer or owner)
+		}`,
+				Relationships: []string{
+					"document:1#system@user:1",
+				},
+				Scenarios: []file.Scenario{
+					{
+						Name:        "scenario 1",
+						Description: "only exercises the system branch",
+						Checks: []file.Check{
+							{
+								Entity:  "document:1",
+								Subject: "user:1",
+								Assertions: map[string]bool{
+									"view": true,
+								},
+							},
+						},
+						EntityFilters: []file.EntityFilter{},
+					},
+				},
+			})
+
+			Expect(sci.EntityCoverageInfo[1].EntityName).Should(Equal("document"))
+			Expect(sci.EntityCoverageInfo[1].UncoveredAssertions).Should(Equal(map[string][]string{}))
+			Expect(sci.EntityCoverageInfo[1].CoverageAssertionsPercent["scenario 1"]).Should(Equal(100))
+			Expect(isSameArray(sci.EntityCoverageInfo[1].UncoveredAssertionComponents["scenario 1"], []string{
+				"document#view[owner]",
+				"document#view[viewer]",
+			})).Should(Equal(true))
+			Expect(sci.EntityCoverageInfo[1].CoverageAssertionComponentsPercent["scenario 1"]).Should(Equal(33))
+			Expect(sci.TotalAssertionsCoverage).Should(Equal(66))
+		})
+
 		It("Case 3: Facebook Groups", func() {
 			sci := Run(file.Shape{
 				Schema: `


### PR DESCRIPTION
﻿/claim #837

## Summary

Fixes #837.

This updates the coverage analyzer so a permission/action assertion can report branch-level condition coverage instead of treating one satisfied branch as complete coverage for the whole permission.

Changes:
- Extract leaf components from permission rewrites, including direct relations, tuple-to-userset references, attributes, and rule calls.
- Track uncovered assertion components per scenario alongside the existing top-level uncovered assertions.
- Use detailed component coverage when calculating total assertion coverage, so partially exercised permissions lower the overall coverage score.
- Display uncovered assertion components and their per-scenario coverage in the CLI output.
- Add a regression test for a permission shaped like `system or (viewer or owner)` where only the `system` branch is exercised.

## Demo video
- Short proof video: https://github.com/Iineman2/permify/releases/download/permify-837-demo/permify-837-demo.mp4
- Shows the partial-coverage regression where iew = system or (viewer or owner) now reports uncovered assertion components instead of treating the permission as fully covered.

## Verification

```bash
go test ./pkg/development/coverage
go test ./pkg/cmd ./pkg/development/coverage
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Coverage reporting now shows uncovered assertion components per key.
  - Adds per-key assertion-component coverage percentages with color-coded success/danger indicators (50% threshold).
  - Aggregated coverage now reflects component-level percentages.

* **Tests**
  - Added tests validating component-level coverage across branched, cross-entity, and nested permission scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Permify/permify/pull/2955)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
