### PR TITLE
fix(metric): remove unbounded subject_id from check metric labels

### DIFF
--- a/internal/invoke/invoke.go
+++ b/internal/invoke/invoke.go
@@ -110,12 +110,15 @@ func (invoker *DirectInvoker) Check(ctx context.Context, request *base.Permissio
 		attribute.KeyValue{Key: "subject", Value: attribute.StringValue(tuple.SubjectToString(request.GetSubject()))},
 	))
 	defer span.End()
+	// Use only bounded-cardinality `subject_type` as a metric label.
+	// Do NOT include `subject_id`: it has unbounded cardinality (one per end-user),
+	// causing OTel metric series to grow monotonically. Each Prometheus scrape then
+	// triggers `aggregate.reset` to allocate hundreds of MB, leading to a GC storm
+	// where mark/scan workers consume 80%+ CPU.
 	invoker.checkHistogram.Record(ctx, 1,
-		metric.WithAttributeSet(
-			attribute.NewSet(
-				attribute.KeyValue{Key: "subject_id", Value: attribute.StringValue(request.GetSubject().GetId())},
-				attribute.KeyValue{Key: "subject_type", Value: attribute.StringValue(request.GetSubject().GetType())},
-			)),
+		metric.WithAttributes(
+			attribute.String("subject_type", request.GetSubject().GetType()),
+		),
 	)
 
 	// Validate the depth of the request.


### PR DESCRIPTION
## Bug

`internal/invoke/invoke.go:Check` records the `check` histogram with `subject_id` (the end-user identifier) as a metric label via `attribute.NewSet`:

```go
invoker.checkHistogram.Record(ctx, 1,
    metric.WithAttributeSet(
        attribute.NewSet(
            attribute.KeyValue{Key: "subject_id", ...},
            attribute.KeyValue{Key: "subject_type", ...},
        )),
)
```

`subject_id` is an unbounded-cardinality dimension (one value per end-user). Each unique `(subject_id, subject_type)` combination creates a new OpenTelemetry metric series that is **never reclaimed** for the process lifetime.

This is a textbook [high-cardinality label anti-pattern](https://prometheus.io/docs/practices/naming/#labels) and causes severe performance degradation in production.

## Production Impact

We observed the following in a real cluster (Permify v1.5, 20 pods, 4 CPU / 4 GiB each, ~150 Check QPS):

| Metric | Day 0 | Day 7 |
|---|---|---|
| Active subjects (= `subject_id` cardinality) | ~5,000 | 33,563 |
| `check_total` series count | ~5,000 | 33,563 |
| `/metrics` payload | ~600 KB | **4.5 MB** |
| Single-pod CPU | ~400m | **~3000m** |

Notably, **QPS, cache hit rate, and write traffic did not change** between Day 0 and Day 7. The CPU rise was driven entirely by the growing metric series count.

### CPU profile (60s, single pod)

```
Total samples = 184.61s (306.55%)

      flat  flat%   sum%        cum   cum%
     0.01s 0.0054% 0.022%    159.71s 86.51%  runtime.gcBgMarkWorker
     8.71s  4.72%  4.74%    159.51s 86.40%  runtime.gcDrain
    50.64s 27.43% 32.17%    150.45s 81.50%  runtime.scanobject
    37.23s 20.17% 52.34%     42.82s 23.19%  runtime.findObject
    ...
     7.07s  3.83%  ...    permify/internal/engines.checkRun.func1
```

**86% of CPU is in GC mark/scan**, while business logic (`engines.checkRun`) only accounts for 3.83%.

### Heap profile (`-alloc_space`, 30s window)

```
  208.18MB  22.49%  go.opentelemetry.io/otel/sdk/metric/internal/aggregate.reset[
                     go.shape.struct {
                       FilteredAttributes []KeyValue
                       Time time.Time
                       Value int64
                       SpanID []uint8
                       TraceID []uint8
                     }]
```

`aggregate.reset` walks all series on every Prometheus scrape (default 30s interval), allocating a fresh struct (~5 KB) per series. With 33,563 series this produces a **~200 MB allocation burst every 30s**, which directly causes the GC mark/scan pressure observed above.

## Fix

Remove `subject_id` from the metric labels. Keep `subject_type` because it has bounded cardinality (defined by the user's Permify schema, typically <10 enum values), so per-subject-type aggregation is preserved.

```go
invoker.checkHistogram.Record(ctx, 1,
    metric.WithAttributes(
        attribute.String("subject_type", request.GetSubject().GetType()),
    ),
)
```

Note: the other counters in this file already follow this pattern correctly:
- `lookupEntityHistogram.Record(ctx, 1)` (no labels)
- `lookupSubjectHistogram.Record(ctx, 1)` (no labels)
- `subjectPermissionHistogram.Record(ctx, 1)` (no labels)

This change brings `checkHistogram` in line with those.

## Expected Result After Fix

| Metric | Before | After (expected) |
|---|---|---|
| `check` series count | 33,563 | ~10 (= number of subject types) |
| `/metrics` payload | 4.5 MB | ~50 KB |
| Per-scrape allocation | 200+ MB | < 1 MB |
| Single-pod CPU (no workload change) | ~3000m | ~400m |

## References

- [Prometheus best practices on label cardinality](https://prometheus.io/docs/practices/naming/#labels)
- [OpenTelemetry metric data model](https://opentelemetry.io/docs/specs/otel/metrics/data-model/)

## Backwards Compatibility

This is a metrics-only change. There is no API or wire-format compatibility impact. Operators relying on per-subject_id metric breakdown (which we believe is uncommon, given the cardinality issue) can use distributed tracing (OTel spans, which already include subject info) for that purpose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized OpenTelemetry metrics collection by adjusting metric label configuration to ensure better performance and prevent cardinality-related issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Permify/permify/pull/2957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->