### PR TITLE
fix(lexer): prevent panic on unterminated string literal

### DIFF
--- a/pkg/dsl/lexer/lexer.go
+++ b/pkg/dsl/lexer/lexer.go
@@ -228,7 +228,13 @@ func (l *Lexer) lexString() string {
 		}
 		l.readChar()
 	}
-	str += l.input[position:l.position]
+	end := l.position
+	if end > len(l.input) {
+		end = len(l.input)
+	}
+	if position < end {
+		str += l.input[position:end]
+	}
 	if l.ch == '"' {
 		l.readChar()
 	}

--- a/pkg/dsl/lexer/lexer_test.go
+++ b/pkg/dsl/lexer/lexer_test.go
@@ -1189,4 +1189,17 @@ rule test_rule(created_at time, started_at time) {
 		Expect(hasBoolean).Should(BeTrue())
 		Expect(hasComparison).Should(BeTrue())
 	})
+
+	It("Case 4 - should not panic on an unterminated string", func() {
+		for _, input := range []string{`"\`, `"`, `"abc\`, `"\\`} {
+			Expect(func() {
+				l := NewLexer(input)
+				for {
+					if l.NextToken().Type == token.EOF {
+						break
+					}
+				}
+			}).ShouldNot(Panic())
+		}
+	})
 })


### PR DESCRIPTION
Closes #3004

The DSL lexer panics with a slice-out-of-range on an unterminated string that ends in a backslash (smallest input: `"\`), reachable via SchemaWrite. Clamp the final slice in `lexString` to the input length. Adds a lexer test over several unterminated-string inputs that panics before this change and passes after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the lexer when processing unterminated or malformed string inputs. The system now handles these edge cases gracefully without panicking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->