### PR TITLE
fix(dsl): prevent lexer panic on string ending in trailing backslash

### DIFF
--- a/pkg/dsl/lexer/lexer.go
+++ b/pkg/dsl/lexer/lexer.go
@@ -212,6 +212,12 @@ func (l *Lexer) lexString() string {
 		if l.ch == '\\' {
 			str += l.input[position:l.position]
 			l.readChar() // Skip the backslash
+			if l.ch == 0 {
+				// Unterminated string: input ended right after a trailing
+				// backslash, so there's no character left to escape.
+				position = l.position
+				break
+			}
 			switch l.ch {
 			case 'n':
 				str += "\n"

--- a/pkg/dsl/lexer/lexer_test.go
+++ b/pkg/dsl/lexer/lexer_test.go
@@ -1189,4 +1189,20 @@ rule test_rule(created_at time, started_at time) {
 		Expect(hasBoolean).Should(BeTrue())
 		Expect(hasComparison).Should(BeTrue())
 	})
+
+	It("Case 11 - Unterminated string ending in a trailing backslash should not panic", func() {
+		// Regression test: a string literal that ends right after a backslash
+		// (no character left to escape) used to overshoot the input bounds
+		// and panic with a slice-out-of-range error.
+		l := NewLexer("\"\\")
+
+		Expect(func() {
+			for {
+				tok := l.NextToken()
+				if tok.Type == token.EOF {
+					break
+				}
+			}
+		}).ShouldNot(Panic())
+	})
 })


### PR DESCRIPTION
## Bug

The schema DSL lexer panics with a slice-out-of-range error when lexing an unterminated string that ends in a trailing backslash. 
Minimal repro: 

NewParser("\"\\").Parse()
panic: runtime error: slice bounds out of range [:3] with length 2
pkg/dsl/lexer/lexer.go:231

Reached from the SchemaWrite API via Parse(); the gRPC recovery interceptor catches it, so it errors the request instead of crashing the server, but it's still an uncontrolled panic on untrusted input.

## Root cause

In lexString, when a \ is the last character of the input, l.readChar() (skipping the backslash) sets l.ch = 0 but the code still executes position = l.position + 1, advancing position one past len(input). 
The loop then exits on l.ch == 0, and the final str += l.input[position:l.position] slices with a start index greater than the string length, panicking.

## Fix

Detect l.ch == 0 immediately after skipping the backslash and break early with position = l.position, treating it as an unterminated string instead of continuing to advance past the input bounds.

## Testing

Added a regression test in lexer_test.go asserting the lexer doesn't panic on "\"\\", and verified the exact reporter NewParser("\"\\").Parse()) now returns cleanly. Full pkg/dsl/...  suite still passes.

Closes #3004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the DSL parser when processing string literals with unterminated escape sequences.

* **Tests**
  * Added test coverage to verify the parser handles malformed strings gracefully without panicking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->