### PR TITLE
fix(dsl): avoid panic on unterminated string escape at EOF

### DIFF
--- a/pkg/dsl/lexer/lexer.go
+++ b/pkg/dsl/lexer/lexer.go
@@ -212,6 +212,11 @@ func (l *Lexer) lexString() string {
 		if l.ch == '\\' {
 			str += l.input[position:l.position]
 			l.readChar() // Skip the backslash
+			if l.ch == 0 {
+				// Backslash at end of input (unterminated escape); stop before
+				// position runs past the input.
+				break
+			}
 			switch l.ch {
 			case 'n':
 				str += "\n"

--- a/pkg/dsl/lexer/lexer_test.go
+++ b/pkg/dsl/lexer/lexer_test.go
@@ -1189,4 +1189,13 @@ rule test_rule(created_at time, started_at time) {
 		Expect(hasBoolean).Should(BeTrue())
 		Expect(hasComparison).Should(BeTrue())
 	})
+
+	It("Unterminated string ending in a backslash does not panic", func() {
+		// A quote followed by a trailing backslash reaches EOF mid-escape.
+		l := NewLexer("\"\\")
+
+		var tok token.Token
+		Expect(func() { tok = l.NextToken() }).ShouldNot(Panic())
+		Expect(tok.Type).Should(BeEquivalentTo(token.STRING))
+	})
 })


### PR DESCRIPTION
Fixes #3004.

When the schema lexer reaches a backslash that is the final character of the input (an unterminated escape), `readChar` sets `l.ch` to 0 at EOF and `position` is then advanced past the end of the input, so the trailing `str += l.input[position:l.position]` slices out of bounds. The smallest trigger is a quote followed by a backslash (`"\`), reached from SchemaWrite via `Parse()`. This breaks out of the escape branch when EOF is hit before `position` overshoots, so the malformed string lexes as a normal STRING token instead of panicking. Added a lexer test that panics without the guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string parsing to safely handle a trailing backslash at the end of input.
  * Prevented crashes when an escape sequence is cut off before completion.
  * Added test coverage for unterminated string escapes to confirm tokenization remains stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->