### PR TITLE
feat(server): add configurable shutdown delay for graceful termination

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,11 +27,12 @@ type (
 
 	// Server contains the configurations for both HTTP and gRPC servers.
 	Server struct {
-		Host         string `mapstructure:"host"` // Host for servers
-		HTTP         HTTP   `mapstructure:"http"` // HTTP server configuration
-		GRPC         GRPC   `mapstructure:"grpc"` // gRPC server configuration
-		NameOverride string `mapstructure:"name_override"`
-		RateLimit    int64  `mapstructure:"rate_limit"` // Rate limit configuration
+		Host          string        `mapstructure:"host"` // Host for servers
+		HTTP          HTTP          `mapstructure:"http"` // HTTP server configuration
+		GRPC          GRPC          `mapstructure:"grpc"` // gRPC server configuration
+		NameOverride  string        `mapstructure:"name_override"`
+		RateLimit     int64         `mapstructure:"rate_limit"`     // Rate limit configuration
+		ShutdownDelay time.Duration `mapstructure:"shutdown_delay"` // Delay before graceful shutdown starts, to allow time to stop routing traffic
 	}
 
 	// HTTP contains configuration for the HTTP server.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,7 @@ func TestNewConfig_FileNotFound(t *testing.T) {
 	assert.Equal(t, "127.0.0.1", cfg.Server.HTTP.GRPCTargetHost)
 	assert.Equal(t, "3478", cfg.Server.GRPC.Port)
 	assert.Equal(t, "info", cfg.Log.Level)
+	assert.Equal(t, time.Duration(0), cfg.Server.ShutdownDelay)
 }
 
 func TestNewConfig(t *testing.T) {
@@ -257,4 +259,23 @@ invalid config
 	cfg, err := NewConfigWithFile(tmpFile) // Load config
 	assert.Nil(t, cfg)                     // Config should be nil
 	assert.Error(t, err)                   // Error expected
+}
+
+func TestNewConfigWithFile_ShutdownDelay(t *testing.T) {
+	configContent := []byte(`
+server:
+  shutdown_delay: 5s
+`)
+	tmpDir, err := os.MkdirTemp("", "shutdown-delay-config-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	tmpFile := filepath.Join(tmpDir, "config.yaml")
+	err = os.WriteFile(tmpFile, configContent, 0o600)
+	require.NoError(t, err)
+
+	cfg, err := NewConfigWithFile(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, 5*time.Second, cfg.Server.ShutdownDelay)
 }

--- a/internal/servers/server.go
+++ b/internal/servers/server.go
@@ -366,6 +366,11 @@ func (s *Container) Run(
 	// Wait for the context to be canceled (e.g., due to a signal).
 	<-ctx.Done()
 
+	if srv.ShutdownDelay > 0 {
+		slog.Info(fmt.Sprintf("waiting %s before shutdown", srv.ShutdownDelay))
+		time.Sleep(srv.ShutdownDelay)
+	}
+
 	// Shutdown the servers gracefully.
 	ctxShutdown, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()

--- a/internal/servers/server_behavior_test.go
+++ b/internal/servers/server_behavior_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -17,6 +18,7 @@ import (
 	health "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
+	"github.com/Permify/permify/internal/config"
 	"github.com/Permify/permify/internal/storage"
 	"github.com/Permify/permify/pkg/database"
 	v1 "github.com/Permify/permify/pkg/pb/base/v1"
@@ -538,5 +540,47 @@ func TestBundleServerValidationAndStorageErrors(t *testing.T) {
 	})
 	if status.Code(err) != codes.NotFound {
 		t.Fatalf("expected not found status, got %v", status.Code(err))
+	}
+}
+
+func TestServerShutdownDelay(t *testing.T) {
+	container := NewContainer(
+		nil,
+		storage.NewNoopRelationshipReader(),
+		storage.NewNoopDataWriter(),
+		storage.NewNoopBundleReader(),
+		storage.NewNoopBundleWriter(),
+		storage.NewNoopSchemaReader(),
+		storage.NewNoopSchemaWriter(),
+		storage.NewNoopTenantReader(),
+		storage.NewNoopTenantWriter(),
+		storage.NewNoopWatcher(),
+	)
+
+	srv := &config.Server{
+		RateLimit:     1000,
+		GRPC:          config.GRPC{Port: "0"},
+		HTTP:          config.HTTP{Enabled: false},
+		ShutdownDelay: 200 * time.Millisecond,
+	}
+	dst := &config.Distributed{Port: "0"}
+	profiler := &config.Profiler{Enabled: false}
+
+	var cancelledAt time.Time
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancelledAt = time.Now()
+		cancel()
+	}()
+
+	err := container.Run(ctx, srv, slog.Default(), dst, nil, profiler, nil)
+	elapsed := time.Since(cancelledAt)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed < 200*time.Millisecond {
+		t.Fatalf("expected at least 200ms delay after cancellation, got %v", elapsed)
 	}
 }

--- a/pkg/cmd/flags/serve.go
+++ b/pkg/cmd/flags/serve.go
@@ -29,6 +29,13 @@ func RegisterServeFlags(flags *pflag.FlagSet) {
 		panic(err)
 	}
 
+	if err = viper.BindPFlag("server.shutdown_delay", flags.Lookup("server-shutdown-delay")); err != nil {
+		panic(err)
+	}
+	if err = viper.BindEnv("server.shutdown_delay", "PERMIFY_SHUTDOWN_DELAY"); err != nil {
+		panic(err)
+	}
+
 	if err = viper.BindPFlag("server.host", flags.Lookup("server-host")); err != nil {
 		panic(err)
 	}

--- a/pkg/cmd/serve.go
+++ b/pkg/cmd/serve.go
@@ -60,6 +60,7 @@ func NewServeCommand() *cobra.Command {
 	f.Bool("http-enabled", conf.Server.HTTP.Enabled, "switch option for HTTP server")
 	f.String("account-id", conf.AccountID, "account id")
 	f.Int64("server-rate-limit", conf.Server.RateLimit, "the maximum number of requests the server should handle per second")
+	f.Duration("server-shutdown-delay", conf.Server.ShutdownDelay, "shutdown delay allowing time to stop routing traffic")
 	f.String("server-host", conf.Server.Host, "host/interface to bind the HTTP server")
 	f.String("server-name-override", conf.Server.NameOverride, "server name override")
 	f.String("grpc-port", conf.Server.GRPC.Port, "port that GRPC server run on")

--- a/pkg/cmd/serve_test.go
+++ b/pkg/cmd/serve_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Permify/permify/internal/config"
+	"github.com/Permify/permify/pkg/cmd/flags"
+)
+
+func TestShutdownDelayFlag(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	cmd := NewServeCommand()
+	assert.NoError(t, cmd.ParseFlags([]string{"--server-shutdown-delay=5s"}))
+	flags.RegisterServeFlags(cmd.Flags())
+
+	var cfg config.Config
+	assert.NoError(t, viper.Unmarshal(&cfg))
+	assert.Equal(t, 5*time.Second, cfg.Server.ShutdownDelay)
+}
+
+func TestShutdownDelayEnvVar(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	t.Setenv("PERMIFY_SHUTDOWN_DELAY", "10s")
+
+	cmd := NewServeCommand()
+	flags.RegisterServeFlags(cmd.Flags())
+
+	var cfg config.Config
+	assert.NoError(t, viper.Unmarshal(&cfg))
+	assert.Equal(t, 10*time.Second, cfg.Server.ShutdownDelay)
+}


### PR DESCRIPTION
## Summary

Adds a `server.shutdown_delay` configuration option that introduces a delay between receiving SIGTERM and starting graceful shutdown.

When Permify runs in Kubernetes, pod termination and endpoint de-registration happen concurrently. Without a delay, `GracefulStop()` closes the gRPC listener before kube-proxy finishes updating iptables, causing `connection refused` and `RST_STREAM` errors for clients during rolling deployments.

This is the same pattern used by kube-apiserver (`--shutdown-delay-duration`)

## Configuration

- YAML: `server.shutdown_delay: 5s`
- Flag: `--server-shutdown-delay=5s`
- Env: `PERMIFY_SHUTDOWN_DELAY=5s`

Defaults to `0`, meaning no behavior change for existing users.

## Changes

- `internal/config/config.go` adds `ShutdownDelay` field to `Server` struct
- `internal/servers/server.go` sleeps for configured delay after `<-ctx.Done()` before shutdown
- `pkg/cmd/serve.go` registers `--server-shutdown-delay` CLI flag
- `pkg/cmd/flags/serve.go` binds flag and env var to viper
- `internal/config/config_test.go` tests for default value and YAML parsing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `server-shutdown-delay` to control an optional delay before graceful server shutdown begins.
  * Configurable via command-line option, `server.shutdown_delay` in config files, or `PERMIFY_SHUTDOWN_DELAY`.
  * Supports duration values (e.g., `5s`); shutdown remains immediate when unset or `0`.

* **Tests**
  * Extended unit tests to validate default values, config/file parsing, CLI flag handling, environment variable handling, and enforced shutdown timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->