### PR TITLE
test(schema): add schema walker direct relation invariant and not found specs

### DIFF
--- a/internal/schema/walker_test.go
+++ b/internal/schema/walker_test.go
@@ -468,5 +468,32 @@ var _ = Describe("walker", func() {
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(Equal(base.ErrorCode_ERROR_CODE_ENTITY_DEFINITION_NOT_FOUND.String()))
 		})
+
+		It("should validate schema walker invariant on direct relation without action definition error", func() {
+			sch, err := parser.NewParser(`
+			entity user {}
+			entity team {
+				relation lead @user
+				relation member @user
+				permission manage = lead
+			}
+			`).Parse()
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			c := compiler.NewCompiler(true, sch)
+			e, r, err := c.Compile()
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			w := NewWalker(NewSchemaFromEntityAndRuleDefinitions(e, r))
+
+			err = w.Walk("team", "manage")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			err = w.Walk("team", "non_existent_permission")
+			Expect(err).Should(HaveOccurred())
+		})
 	})
 })
+


### PR DESCRIPTION
### Summary
- Adds unit tests to `internal/schema/walker_test.go` validating schema walker behavior when traversing direct relation references.
- Validates error propagation behavior when referencing undefined entity actions and non-existent permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for successful schema permission traversal.
  - Added validation that requesting a nonexistent permission returns an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->