### PR TITLE
test(schema): add multi-level nested permission reference traversal test

### DIFF
--- a/internal/schema/walker_test.go
+++ b/internal/schema/walker_test.go
@@ -468,5 +468,33 @@ var _ = Describe("walker", func() {
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(Equal(base.ErrorCode_ERROR_CODE_ENTITY_DEFINITION_NOT_FOUND.String()))
 		})
+
+		It("should successfully traverse multi-level nested permission references without error", func() {
+			sch, err := parser.NewParser(`
+			entity user {}
+			entity space {
+				relation owner @user
+				permission manage = owner
+			}
+			entity folder {
+				relation parent @space
+				relation editor @user
+				permission edit = editor or parent.manage
+			}
+			`).Parse()
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			c := compiler.NewCompiler(true, sch)
+			e, r, err := c.Compile()
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			w := NewWalker(NewSchemaFromEntityAndRuleDefinitions(e, r))
+
+			err = w.Walk("folder", "edit")
+			Expect(err).ShouldNot(HaveOccurred())
+		})
 	})
 })
+


### PR DESCRIPTION
### Summary
- Adds unit tests to `internal/schema/walker_test.go` verifying that multi-level nested permission references traverse clean inheritance hierarchies without error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming successful traversal of multi-level nested permission references.
  - Verifies that nested permissions compile and can be walked without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->