### PR TITLE
test(schema): add self-referential entity relation cycle termination test

### DIFF
--- a/internal/schema/walker_test.go
+++ b/internal/schema/walker_test.go
@@ -468,5 +468,29 @@ var _ = Describe("walker", func() {
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(Equal(base.ErrorCode_ERROR_CODE_ENTITY_DEFINITION_NOT_FOUND.String()))
 		})
+
+		It("should terminate cleanly on self-referential entity hierarchy without infinite loop", func() {
+			sch, err := parser.NewParser(`
+			entity user {}
+			entity node {
+				relation parent @node
+				relation owner @user
+				permission view = owner or parent.view
+			}
+			`).Parse()
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			c := compiler.NewCompiler(true, sch)
+			e, r, err := c.Compile()
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			w := NewWalker(NewSchemaFromEntityAndRuleDefinitions(e, r))
+
+			err = w.Walk("node", "view")
+			Expect(err).ShouldNot(HaveOccurred())
+		})
 	})
 })
+


### PR DESCRIPTION
### Summary
- Adds unit tests to `internal/schema/walker_test.go` ensuring that self-referential entity relation trees terminate cleanly during schema walking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented entity hierarchy walking from getting stuck in an infinite loop when relationships refer back to the same entity.
  - Self-referential permission checks now complete cleanly without returning an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->