### PR TITLE
test(schema): add multi-term permission union chain traversal spec

### DIFF
--- a/internal/schema/walker_test.go
+++ b/internal/schema/walker_test.go
@@ -491,6 +491,31 @@ var _ = Describe("walker", func() {
 			err = w.Walk("node", "view")
 			Expect(err).ShouldNot(HaveOccurred())
 		})
+
+		It("should successfully evaluate multi-term permission union chains", func() {
+			sch, err := parser.NewParser(`
+			entity user {}
+			entity project {
+				relation admin @user
+				relation lead @user
+				relation contributor @user
+				permission write = admin or lead or contributor
+			}
+			`).Parse()
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			c := compiler.NewCompiler(true, sch)
+			e, r, err := c.Compile()
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			w := NewWalker(NewSchemaFromEntityAndRuleDefinitions(e, r))
+
+			err = w.Walk("project", "write")
+			Expect(err).ShouldNot(HaveOccurred())
+		})
 	})
 })
+
 

--- a/internal/schema/walker_test.go
+++ b/internal/schema/walker_test.go
@@ -468,5 +468,29 @@ var _ = Describe("walker", func() {
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(Equal(base.ErrorCode_ERROR_CODE_ENTITY_DEFINITION_NOT_FOUND.String()))
 		})
+
+		It("should terminate cleanly on self-referential entity hierarchy without infinite loop", func() {
+			sch, err := parser.NewParser(`
+			entity user {}
+			entity node {
+				relation parent @node
+				relation owner @user
+				permission view = owner or parent.view
+			}
+			`).Parse()
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			c := compiler.NewCompiler(true, sch)
+			e, r, err := c.Compile()
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			w := NewWalker(NewSchemaFromEntityAndRuleDefinitions(e, r))
+
+			err = w.Walk("node", "view")
+			Expect(err).ShouldNot(HaveOccurred())
+		})
 	})
 })
+


### PR DESCRIPTION
### Summary
- Adds unit tests to `internal/schema/walker_test.go` ensuring that multi-term permission disjunction chains (`admin or lead or contributor`) traverse entity permissions successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring self-referential entity hierarchies complete without infinite loops.
  * Added coverage for correctly evaluating permissions composed of multiple union terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->