### PR TITLE
test(dsl): add IN keyword lookup and correct IsIgnores context spec

### DIFF
--- a/pkg/dsl/token/token_test.go
+++ b/pkg/dsl/token/token_test.go
@@ -32,6 +32,7 @@ var _ = Describe("token", func() {
 				{target: "permission", expected: PERMISSION},
 				{target: "attribute", expected: ATTRIBUTE},
 				{target: "rule", expected: RULE},
+				{target: "in", expected: IN},
 			}
 
 			for _, tt := range tests {
@@ -40,7 +41,7 @@ var _ = Describe("token", func() {
 		})
 	})
 
-	Context("LookupKeywords", func() {
+	Context("IsIgnores", func() {
 		It("Case 1", func() {
 			tests := []struct {
 				target   Type


### PR DESCRIPTION
### Summary
- Adds unit coverage for the `IN` keyword in `token.LookupKeywords` to verify token mapping.
- Corrects duplicate context description to `IsIgnores` in `token_test.go` for test suite clarity and reporting accuracy.

### Testing
- Validates token lookup against defined DSL keywords.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for recognizing the `in` keyword.
  - Corrected a test label to accurately describe the behavior being tested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->