### PR TITLE
test(dsl): add delimiter and symbol token Type String stringer specs

### DIFF
--- a/pkg/dsl/token/token_test.go
+++ b/pkg/dsl/token/token_test.go
@@ -74,6 +74,11 @@ var _ = Describe("token", func() {
 				{target: SPACE, expected: "SPACE"},
 				{target: TAB, expected: "TAB"},
 				{target: RULE, expected: "RULE"},
+				{target: COMMA, expected: "COMMA"},
+				{target: COLON, expected: "COLON"},
+				{target: HASH, expected: "HASH"},
+				{target: ASSIGN, expected: "ASSIGN"},
+				{target: EOF, expected: "EOF"},
 			}
 
 			for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Expands unit test coverage for `token.Type.String()` method across DSL delimiter and structural symbols (`COMMA`, `COLON`, `HASH`, `ASSIGN`, `EOF`).
- Asserts consistency between token types and stringer representations.

### Testing
- Validates equality of string conversions against defined symbol constants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for string representations of comma, colon, hash, assignment, and end-of-file tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->