### PR TITLE
test(dsl): add PositionInfo and character token initialization specs for MOD and POW

### DIFF
--- a/pkg/dsl/token/token_test.go
+++ b/pkg/dsl/token/token_test.go
@@ -118,6 +118,34 @@ var _ = Describe("token", func() {
 						Literal: "'",
 					},
 				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   10,
+						ColumnPosition: 5,
+					}, typ: MOD, ch: '%',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   10,
+							ColumnPosition: 5,
+						},
+						Type:    MOD,
+						Literal: "%",
+					},
+				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   10,
+						ColumnPosition: 11,
+					}, typ: POW, ch: '^',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   10,
+							ColumnPosition: 11,
+						},
+						Type:    POW,
+						Literal: "^",
+					},
+				},
 			}
 
 			for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Extends unit test coverage for `token.New` across modulo (`%`) and exponentiation (`^`) symbols.
- Asserts literal matching, position coordinates (`LinePosition`, `ColumnPosition`), and type constants (`MOD`, `POW`).

### Testing
- Validates field equality against constructed token instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for recognizing modulo (`%`) and exponentiation (`^`) operators, including their source positions and literal values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->