### PR TITLE
test(dsl): add PositionInfo specs for HASH and QM tokens

### DIFF
--- a/pkg/dsl/token/token_test.go
+++ b/pkg/dsl/token/token_test.go
@@ -118,6 +118,34 @@ var _ = Describe("token", func() {
 						Literal: "'",
 					},
 				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   12,
+						ColumnPosition: 3,
+					}, typ: HASH, ch: '#',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   12,
+							ColumnPosition: 3,
+						},
+						Type:    HASH,
+						Literal: "#",
+					},
+				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   12,
+						ColumnPosition: 8,
+					}, typ: QM, ch: '?',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   12,
+							ColumnPosition: 8,
+						},
+						Type:    QM,
+						Literal: "?",
+					},
+				},
 			}
 
 			for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Extends unit test coverage in `pkg/dsl/token` for hash (`#`) and question mark (`?`) token instantiation.
- Verifies literal token resolution and source code coordinate attribution.

### Testing
- Tested with ginkgo/gomega expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for hash (`#`) and question mark (`?`) token recognition, including position and literal values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->