### PR TITLE
test(dsl): add PositionInfo specs for NOT (!) token initialization

### DIFF
--- a/pkg/dsl/token/token_test.go
+++ b/pkg/dsl/token/token_test.go
@@ -118,6 +118,20 @@ var _ = Describe("token", func() {
 						Literal: "'",
 					},
 				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   18,
+						ColumnPosition: 2,
+					}, typ: NOT, ch: '!',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   18,
+							ColumnPosition: 2,
+						},
+						Type:    NOT,
+						Literal: "!",
+					},
+				},
 			}
 
 			for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds unit test verification for negation token (`!`) in `token.New`.

### Testing
- Tested with ginkgo/gomega expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying recognition of the `NOT` token represented by `!`, including its source position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->