### PR TITLE
test(dsl): add PositionInfo specs for PIPE (|) and TILDE (~) token initialization

### DIFF
--- a/pkg/dsl/token/token_test.go
+++ b/pkg/dsl/token/token_test.go
@@ -118,6 +118,34 @@ var _ = Describe("token", func() {
 						Literal: "'",
 					},
 				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   25,
+						ColumnPosition: 2,
+					}, typ: PIPE, ch: '|',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   25,
+							ColumnPosition: 2,
+						},
+						Type:    PIPE,
+						Literal: "|",
+					},
+				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   25,
+						ColumnPosition: 6,
+					}, typ: TILDE, ch: '~',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   25,
+							ColumnPosition: 6,
+						},
+						Type:    TILDE,
+						Literal: "~",
+					},
+				},
 			}
 
 			for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds unit test verification for pipe (`|`) and tilde (`~`) tokens in `token.New`.

### Testing
- Tested with ginkgo/gomega expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for recognizing pipe (`|`) and tilde (`~`) tokens.
  * Verified that these tokens are created with the expected type, position, and value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->