### PR TITLE
test(dsl): add PositionInfo specs for AND (&) and OR (|) token initialization

### DIFF
--- a/pkg/dsl/token/token_test.go
+++ b/pkg/dsl/token/token_test.go
@@ -118,6 +118,34 @@ var _ = Describe("token", func() {
 						Literal: "'",
 					},
 				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   28,
+						ColumnPosition: 1,
+					}, typ: AND, ch: '&',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   28,
+							ColumnPosition: 1,
+						},
+						Type:    AND,
+						Literal: "&",
+					},
+				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   28,
+						ColumnPosition: 5,
+					}, typ: OR, ch: '|',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   28,
+							ColumnPosition: 5,
+						},
+						Type:    OR,
+						Literal: "|",
+					},
+				},
 			}
 
 			for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds unit test verification for conjunction (`&`) and disjunction (`|`) tokens in `token.New`.

### Testing
- Tested with ginkgo/gomega expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for creating `AND` and `OR` tokens, including their symbols and source positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->