### PR TITLE
test(dsl): add PositionInfo specs for EQUAL (=) and EXCL (!) token initialization

### DIFF
--- a/pkg/dsl/token/token_test.go
+++ b/pkg/dsl/token/token_test.go
@@ -118,6 +118,34 @@ var _ = Describe("token", func() {
 						Literal: "'",
 					},
 				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   30,
+						ColumnPosition: 2,
+					}, typ: EQUAL, ch: '=',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   30,
+							ColumnPosition: 2,
+						},
+						Type:    EQUAL,
+						Literal: "=",
+					},
+				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   30,
+						ColumnPosition: 7,
+					}, typ: EXCL, ch: '!',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   30,
+							ColumnPosition: 7,
+						},
+						Type:    EXCL,
+						Literal: "!",
+					},
+				},
 			}
 
 			for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds unit test verification for assignment/equality (`=`) and exclamation (`!`) tokens in `token.New`.

### Testing
- Tested with ginkgo/gomega expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded token construction test coverage for equality and exclusion operators, including their positions, types, and literal values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->