### PR TITLE
test(dsl): add PositionInfo specs for LBRACKET ([) and RBRACKET (]) token initialization

### DIFF
--- a/pkg/dsl/token/token_test.go
+++ b/pkg/dsl/token/token_test.go
@@ -118,6 +118,34 @@ var _ = Describe("token", func() {
 						Literal: "'",
 					},
 				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   32,
+						ColumnPosition: 1,
+					}, typ: LBRACKET, ch: '[',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   32,
+							ColumnPosition: 1,
+						},
+						Type:    LBRACKET,
+						Literal: "[",
+					},
+				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   32,
+						ColumnPosition: 5,
+					}, typ: RBRACKET, ch: ']',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   32,
+							ColumnPosition: 5,
+						},
+						Type:    RBRACKET,
+						Literal: "]",
+					},
+				},
 			}
 
 			for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds unit test verification for left bracket (`[`) and right bracket (`]`) tokens in `token.New`.

### Testing
- Tested with ginkgo/gomega expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for square-bracket token creation, verifying token positions, types, and literal values for `[` and `]`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->