### PR TITLE
test(dsl): add PositionInfo specs for LBRACE ({) and RBRACE (}) token initialization

### DIFF
--- a/pkg/dsl/token/token_test.go
+++ b/pkg/dsl/token/token_test.go
@@ -118,6 +118,34 @@ var _ = Describe("token", func() {
 						Literal: "'",
 					},
 				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   35,
+						ColumnPosition: 1,
+					}, typ: LBRACE, ch: '{',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   35,
+							ColumnPosition: 1,
+						},
+						Type:    LBRACE,
+						Literal: "{",
+					},
+				},
+				{
+					positionInfo: PositionInfo{
+						LinePosition:   35,
+						ColumnPosition: 5,
+					}, typ: RBRACE, ch: '}',
+					result: Token{
+						PositionInfo: PositionInfo{
+							LinePosition:   35,
+							ColumnPosition: 5,
+						},
+						Type:    RBRACE,
+						Literal: "}",
+					},
+				},
 			}
 
 			for _, tt := range tests {


### PR DESCRIPTION
### Summary
- Adds unit test verification for left brace (`{`) and right brace (`}`) tokens in `token.New`.

### Testing
- Tested with ginkgo/gomega expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added test coverage for left- and right-brace token creation, including position, type, and literal values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->