### PR TITLE
test(dsl): add PositionInfo specs for OR and IN keyword token initialization

### DIFF
--- a/pkg/dsl/token/day2_w20_or_in_test.go
+++ b/pkg/dsl/token/day2_w20_or_in_test.go
@@ -1,0 +1,24 @@
+package token
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Or and In Keyword Token Specs", func() {
+	Context("Token initialization for set and disjunction keywords", func() {
+		It("should correctly identify OR keyword token", func() {
+			tok := New(OR, "or", PositionInfo{LinePosition: 12, ColumnPosition: 4})
+			Expect(tok.Type).To(Equal(OR))
+			Expect(tok.Literal).To(Equal("or"))
+			Expect(tok.PositionInfo.LinePosition).To(Equal(12))
+		})
+
+		It("should correctly identify IN keyword token", func() {
+			tok := New(IN, "in", PositionInfo{LinePosition: 12, ColumnPosition: 15})
+			Expect(tok.Type).To(Equal(IN))
+			Expect(tok.Literal).To(Equal("in"))
+			Expect(tok.PositionInfo.ColumnPosition).To(Equal(15))
+		})
+	})
+})


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `or` and `in` keyword tokens in `token.New`.\n\n### Testing\n- Tested with ginkgo/gomega expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage verifying that `OR` and `IN` tokens preserve their expected types, literals, and source position information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->