### PR TITLE
test(dsl): add PositionInfo specs for RELATION keyword token initialization

### DIFF
--- a/pkg/dsl/token/day2_w26_relation_test.go
+++ b/pkg/dsl/token/day2_w26_relation_test.go
@@ -1,0 +1,17 @@
+package token
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Relation Keyword Token Specs", func() {
+	Context("Token initialization for relation keywords", func() {
+		It("should correctly identify RELATION token", func() {
+			tok := New(RELATION, "relation", PositionInfo{LinePosition: 2, ColumnPosition: 4})
+			Expect(tok.Type).To(Equal(RELATION))
+			Expect(tok.Literal).To(Equal("relation"))
+			Expect(tok.PositionInfo.LinePosition).To(Equal(2))
+		})
+	})
+})


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `relation` schema keyword in `token.New`.\n\n### Testing\n- Tested with ginkgo/gomega expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming that `RELATION` tokens initialize with the expected type, literal value, and source line position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->