### PR TITLE
test(dsl): add PositionInfo specs for PERMISSION keyword token initialization

### DIFF
--- a/pkg/dsl/token/day2_w28_permission_test.go
+++ b/pkg/dsl/token/day2_w28_permission_test.go
@@ -1,0 +1,17 @@
+package token
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Permission Keyword Token Specs", func() {
+	Context("Token initialization for permission keywords", func() {
+		It("should correctly identify PERMISSION token", func() {
+			tok := New(PERMISSION, "permission", PositionInfo{LinePosition: 4, ColumnPosition: 4})
+			Expect(tok.Type).To(Equal(PERMISSION))
+			Expect(tok.Literal).To(Equal("permission"))
+			Expect(tok.PositionInfo.LinePosition).To(Equal(4))
+		})
+	})
+})


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `permission` schema keyword in `token.New`.\n\n### Testing\n- Tested with ginkgo/gomega expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that permission keyword tokens are initialized with the correct type, literal value, and line position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->