### PR TITLE
test(dsl): add PositionInfo specs for RULE keyword token initialization

### DIFF
--- a/pkg/dsl/token/day3_w01_tenant_rule_test.go
+++ b/pkg/dsl/token/day3_w01_tenant_rule_test.go
@@ -1,0 +1,17 @@
+package token
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Tenant and Rule Token Specs", func() {
+	Context("Token initialization for rule keywords", func() {
+		It("should correctly identify RULE keyword token", func() {
+			tok := New(RULE, "rule", PositionInfo{LinePosition: 1, ColumnPosition: 1})
+			Expect(tok.Type).To(Equal(RULE))
+			Expect(tok.Literal).To(Equal("rule"))
+			Expect(tok.PositionInfo.LinePosition).To(Equal(1))
+		})
+	})
+})


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `rule` schema keyword in `token.New`.\n\n### Testing\n- Tested with ginkgo/gomega expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage verifying that `RULE` tokens are created with the correct type, value, and line position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->