### PR TITLE
test(dsl): add PositionInfo specs for ATTRIBUTE keyword token initialization

### DIFF
--- a/pkg/dsl/token/day3_w03_attribute_test.go
+++ b/pkg/dsl/token/day3_w03_attribute_test.go
@@ -1,0 +1,17 @@
+package token
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Attribute Keyword Token Specs", func() {
+	Context("Token initialization for schema attribute keywords", func() {
+		It("should correctly identify ATTRIBUTE keyword token", func() {
+			tok := New(ATTRIBUTE, "attribute", PositionInfo{LinePosition: 3, ColumnPosition: 2})
+			Expect(tok.Type).To(Equal(ATTRIBUTE))
+			Expect(tok.Literal).To(Equal("attribute"))
+			Expect(tok.PositionInfo.LinePosition).To(Equal(3))
+		})
+	})
+})


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `attribute` schema keyword in `token.New`.\n\n### Testing\n- Tested with ginkgo/gomega expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that attribute keyword tokens are initialized with the expected type, text, and line position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->